### PR TITLE
i27: Compile time specification of numeric types

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dust
 Title: Iterate Multiple Realisations of Stochastic Models
-Version: 0.0.1
+Version: 0.0.2
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("John", "Lees", role = "aut"),

--- a/R/interface.R
+++ b/R/interface.R
@@ -15,8 +15,8 @@
 ##'   data`)
 ##'
 ##' * That class must also include typedefs that describe the standard
-##'   floating point and integer types (`float_t` and `int_t`
-##'   respectively). Most models can include `typedef double float_t;`
+##'   floating point and integer types (`real_t` and `int_t`
+##'   respectively). Most models can include `typedef double real_t;`
 ##'   and `typedef int int_t;` in their public section.
 ##'
 ##' * The model must have a method `size()` returning `size_t` which
@@ -26,14 +26,14 @@
 ##'
 ##' * The model must have a method `update` (which may not be
 ##'   `const`), taking a step number (`size_t`) and returning a
-##'   `std::vector<float_t>` of initial state for the model.
+##'   `std::vector<real_t>` of initial state for the model.
 ##'
 ##' * The model must have a method `update` taking arguments:
 ##'   - `size_t step`: the step number
-##'   - `const std::vector<float_t>& state`: the state at the beginning of the
+##'   - `const std::vector<real_t>& state`: the state at the beginning of the
 ##'      step
-##'   - `dust::RNG<float_t, int_t>& rng`: the dust random number generator
-##'   - `std::vector<float_t>& state_next`: the end state of the model
+##'   - `dust::RNG<real_t, int_t>& rng`: the dust random number generator
+##'   - `std::vector<real_t>& state_next`: the end state of the model
 ##'     (to be written to by your function)
 ##'
 ##' Your `update` function is the core here and should update the

--- a/R/interface.R
+++ b/R/interface.R
@@ -14,6 +14,11 @@
 ##'   with a const reference to this type (`const model::init_t&
 ##'   data`)
 ##'
+##' * That class must also include typedefs that describe the standard
+##'   floating point and integer types (`float_t` and `int_t`
+##'   respectively). Most models can include `typedef double float_t;`
+##'   and `typedef int int_t;` in their public section.
+##'
 ##' * The model must have a method `size()` returning `size_t` which
 ##'   returns the size of the system. This size may depend on values
 ##'   in your initialisation object but is constant within a model
@@ -21,14 +26,14 @@
 ##'
 ##' * The model must have a method `update` (which may not be
 ##'   `const`), taking a step number (`size_t`) and returning a
-##'   `std::vector<double>` of initial state for the model.
+##'   `std::vector<float_t>` of initial state for the model.
 ##'
 ##' * The model must have a method `update` taking arguments:
 ##'   - `size_t step`: the step number
-##'   - `const std::vector<double>& state`: the state at the beginning of the
+##'   - `const std::vector<float_t>& state`: the state at the beginning of the
 ##'      step
-##'   - `dust::RNG& rng`: the dust random number generator
-##'   - `std::vector<double>& state_next`: the end state of the model
+##'   - `dust::RNG<float_t, int_t>& rng`: the dust random number generator
+##'   - `std::vector<float_t>& state_next`: the end state of the model
 ##'     (to be written to by your function)
 ##'
 ##' Your `update` function is the core here and should update the

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## dust <img src='man/figures/logo.png' align="right" height="139" />
+# dust <img src='man/figures/logo.png' align="right" height="139" />
 
 <!-- badges: start -->
 [![Project Status: Concept – Minimal or no implementation has been done yet, or the repository is only intended to be a limited example, demo, or proof-of-concept.](https://www.repostatus.org/badges/latest/concept.svg)](https://www.repostatus.org/#concept)

--- a/inst/examples/sir.cpp
+++ b/inst/examples/sir.cpp
@@ -1,7 +1,7 @@
 class sir {
 public:
   typedef int int_t;
-  typedef double walk_t;
+  typedef double real_t;
   struct init_t {
     double beta;
     double dt;

--- a/inst/examples/sir.cpp
+++ b/inst/examples/sir.cpp
@@ -1,7 +1,7 @@
 class sir {
 public:
   typedef int int_t;
-  typedef double float_t;
+  typedef double walk_t;
   struct init_t {
     double beta;
     double dt;

--- a/inst/examples/sir.cpp
+++ b/inst/examples/sir.cpp
@@ -1,5 +1,7 @@
 class sir {
 public:
+  typedef int int_t;
+  typedef double float_t;
   struct init_t {
     double beta;
     double dt;

--- a/inst/examples/sir.cpp
+++ b/inst/examples/sir.cpp
@@ -26,8 +26,8 @@ public:
     return ret;
   }
 
-  void update(size_t step, const std::vector<double> state, dust::RNG& rng,
-              std::vector<double>& state_next) {
+  void update(size_t step, const std::vector<double> state,
+              dust::RNG<double, int>& rng, std::vector<double>& state_next) {
     double S = state[0];
     double I = state[1];
     double R = state[2];

--- a/inst/examples/walk.cpp
+++ b/inst/examples/walk.cpp
@@ -12,8 +12,8 @@ public:
     std::vector<double> ret = {0};
     return ret;
   }
-  void update(size_t step, const std::vector<double>& state, dust::RNG& rng,
-              std::vector<double>& state_next) {
+  void update(size_t step, const std::vector<double>& state,
+              dust::RNG<double, int>& rng, std::vector<double>& state_next) {
     double mean = state[0];
     state_next[0] = rng.rnorm(mean, data_.sd);
   }

--- a/inst/examples/walk.cpp
+++ b/inst/examples/walk.cpp
@@ -1,5 +1,7 @@
 class walk {
 public:
+  typedef int int_t;
+  typedef double float_t;
   struct init_t {
     double sd;
   };

--- a/inst/examples/walk.cpp
+++ b/inst/examples/walk.cpp
@@ -1,7 +1,7 @@
 class walk {
 public:
   typedef int int_t;
-  typedef double float_t;
+  typedef double real_t;
   struct init_t {
     double sd;
   };

--- a/inst/examples/walk.cpp
+++ b/inst/examples/walk.cpp
@@ -3,20 +3,20 @@ public:
   typedef int int_t;
   typedef double real_t;
   struct init_t {
-    double sd;
+    real_t sd;
   };
   walk(const init_t& data) : data_(data) {
   }
   size_t size() const {
     return 1;
   }
-  std::vector<double> initial(size_t step) {
-    std::vector<double> ret = {0};
+  std::vector<real_t> initial(size_t step) {
+    std::vector<real_t> ret = {0};
     return ret;
   }
-  void update(size_t step, const std::vector<double>& state,
-              dust::RNG<double, int>& rng, std::vector<double>& state_next) {
-    double mean = state[0];
+  void update(size_t step, const std::vector<real_t>& state,
+              dust::RNG<real_t, int>& rng, std::vector<real_t>& state_next) {
+    real_t mean = state[0];
     state_next[0] = rng.rnorm(mean, data_.sd);
   }
 private:
@@ -26,6 +26,6 @@ private:
 #include <Rcpp.h>
 template <>
 walk::init_t dust_data<walk>(Rcpp::List data) {
-  double sd = Rcpp::as<double>(data["sd"]);
+  walk::real_t sd = Rcpp::as<walk::real_t>(data["sd"]);
   return walk::init_t{sd};
 }

--- a/inst/include/dust/distr/binomial.hpp
+++ b/inst/include/dust/distr/binomial.hpp
@@ -6,14 +6,14 @@
 namespace dust {
 namespace distr {
 
-template <typename real_t, typename int_t, typename rng_t>
-int_t binomial_inversion(int_t n, real_t prob, rng_t& generator) {
-  real_t geom_sum = 0;
-  int_t num_geom = 0;
+template <typename rng_t>
+double binomial_inversion(double n, double prob, rng_t& generator) {
+  double geom_sum = 0;
+  double num_geom = 0;
 
   while (true) {
-    real_t r = generator.unif_rand();
-    real_t geom = std::ceil(std::log(r) / std::log1p(-prob));
+    double r = generator.unif_rand();
+    double geom = std::ceil(std::log(r) / std::log1p(-prob));
     geom_sum += geom;
     if (geom_sum > n) {
       break;
@@ -23,17 +23,16 @@ int_t binomial_inversion(int_t n, real_t prob, rng_t& generator) {
   return num_geom;
 }
 
-template <typename real_t>
-real_t stirling_approx_tail(real_t k) {
-  static real_t kTailValues[] = {0.0810614667953272,  0.0413406959554092,
+inline double stirling_approx_tail(double k) {
+  static double kTailValues[] = {0.0810614667953272,  0.0413406959554092,
                                  0.0276779256849983,  0.02079067210376509,
                                  0.0166446911898211,  0.0138761288230707,
                                  0.0118967099458917,  0.0104112652619720,
                                  0.00925546218271273, 0.00833056343336287};
   if (k <= 9) {
-    return kTailValues[static_cast<short>(k)];
+    return kTailValues[static_cast<int>(k)];
   }
-  real_t kp1sq = (k + 1) * (k + 1);
+  double kp1sq = (k + 1) * (k + 1);
   return (1.0 / 12 - (1.0 / 360 - 1.0 / 1260 / kp1sq) / kp1sq) / (k + 1);
 }
 

--- a/inst/include/dust/distr/binomial.hpp
+++ b/inst/include/dust/distr/binomial.hpp
@@ -36,9 +36,6 @@ inline double stirling_approx_tail(double k) {
   return (1.0 / 12 - (1.0 / 360 - 1.0 / 1260 / kp1sq) / kp1sq) / (k + 1);
 }
 
-// TODO: Can't template this until I understand why 'n' is coming in
-// as an double and k coming out as a double
-//
 // https://www.tandfonline.com/doi/abs/10.1080/00949659308811496
 template <typename rng_t>
 inline double btrs(double n, double p, rng_t& generator) {

--- a/inst/include/dust/distr/binomial.hpp
+++ b/inst/include/dust/distr/binomial.hpp
@@ -6,14 +6,14 @@
 namespace dust {
 namespace distr {
 
-template <typename RNG>
-double binomial_inversion(double n, double prob, RNG& generator) {
-  double geom_sum = 0;
-  int num_geom = 0;
+template <typename IntType, typename FloatType, typename RNG>
+IntType binomial_inversion(IntType n, FloatType prob, RNG& generator) {
+  FloatType geom_sum = 0;
+  IntType num_geom = 0;
 
   while (true) {
-    double r = generator.unif_rand();
-    double geom = std::ceil(std::log(r) / std::log1p(-prob));
+    FloatType r = generator.unif_rand();
+    FloatType geom = std::ceil(std::log(r) / std::log1p(-prob));
     geom_sum += geom;
     if (geom_sum > n) {
       break;
@@ -23,19 +23,23 @@ double binomial_inversion(double n, double prob, RNG& generator) {
   return num_geom;
 }
 
-inline double stirling_approx_tail(double k) {
-  static double kTailValues[] = {0.0810614667953272,  0.0413406959554092,
-                                 0.0276779256849983,  0.02079067210376509,
-                                 0.0166446911898211,  0.0138761288230707,
-                                 0.0118967099458917,  0.0104112652619720,
-                                 0.00925546218271273, 0.00833056343336287};
+template <typename FloatType>
+FloatType stirling_approx_tail(FloatType k) {
+  static FloatType kTailValues[] = {0.0810614667953272,  0.0413406959554092,
+                                    0.0276779256849983,  0.02079067210376509,
+                                    0.0166446911898211,  0.0138761288230707,
+                                    0.0118967099458917,  0.0104112652619720,
+                                    0.00925546218271273, 0.00833056343336287};
   if (k <= 9) {
-    return kTailValues[static_cast<int>(k)];
+    return kTailValues[static_cast<short>(k)];
   }
-  double kp1sq = (k + 1) * (k + 1);
+  FloatType kp1sq = (k + 1) * (k + 1);
   return (1.0 / 12 - (1.0 / 360 - 1.0 / 1260 / kp1sq) / kp1sq) / (k + 1);
 }
 
+// TODO: Can't template this until I understand why 'n' is coming in
+// as an double and k coming out as a double
+//
 // https://www.tandfonline.com/doi/abs/10.1080/00949659308811496
 template <typename RNG>
 inline double btrs(double n, double p, RNG& generator) {

--- a/inst/include/dust/distr/binomial.hpp
+++ b/inst/include/dust/distr/binomial.hpp
@@ -6,14 +6,14 @@
 namespace dust {
 namespace distr {
 
-template <typename float_t, typename int_t, typename rng_t>
-int_t binomial_inversion(int_t n, float_t prob, rng_t& generator) {
-  float_t geom_sum = 0;
+template <typename real_t, typename int_t, typename rng_t>
+int_t binomial_inversion(int_t n, real_t prob, rng_t& generator) {
+  real_t geom_sum = 0;
   int_t num_geom = 0;
 
   while (true) {
-    float_t r = generator.unif_rand();
-    float_t geom = std::ceil(std::log(r) / std::log1p(-prob));
+    real_t r = generator.unif_rand();
+    real_t geom = std::ceil(std::log(r) / std::log1p(-prob));
     geom_sum += geom;
     if (geom_sum > n) {
       break;
@@ -23,17 +23,17 @@ int_t binomial_inversion(int_t n, float_t prob, rng_t& generator) {
   return num_geom;
 }
 
-template <typename float_t>
-float_t stirling_approx_tail(float_t k) {
-  static float_t kTailValues[] = {0.0810614667953272,  0.0413406959554092,
-                                  0.0276779256849983,  0.02079067210376509,
-                                  0.0166446911898211,  0.0138761288230707,
-                                  0.0118967099458917,  0.0104112652619720,
-                                  0.00925546218271273, 0.00833056343336287};
+template <typename real_t>
+real_t stirling_approx_tail(real_t k) {
+  static real_t kTailValues[] = {0.0810614667953272,  0.0413406959554092,
+                                 0.0276779256849983,  0.02079067210376509,
+                                 0.0166446911898211,  0.0138761288230707,
+                                 0.0118967099458917,  0.0104112652619720,
+                                 0.00925546218271273, 0.00833056343336287};
   if (k <= 9) {
     return kTailValues[static_cast<short>(k)];
   }
-  float_t kp1sq = (k + 1) * (k + 1);
+  real_t kp1sq = (k + 1) * (k + 1);
   return (1.0 / 12 - (1.0 / 360 - 1.0 / 1260 / kp1sq) / kp1sq) / (k + 1);
 }
 
@@ -92,8 +92,8 @@ inline double btrs(double n, double p, rng_t& generator) {
   }
 }
 
-template <typename float_t, typename int_t, typename rng_t>
-int_t rbinom(rng_t& generator, int_t n, float_t p) {
+template <typename real_t, typename int_t, typename rng_t>
+int_t rbinom(rng_t& generator, int_t n, real_t p) {
   int_t draw;
 
   // Early exit:
@@ -112,7 +112,7 @@ int_t rbinom(rng_t& generator, int_t n, float_t p) {
     }
   */
 
-  float_t q = p;
+  real_t q = p;
   if (q > 0.5) {
     q = 1 - q;
   }

--- a/inst/include/dust/distr/binomial.hpp
+++ b/inst/include/dust/distr/binomial.hpp
@@ -6,14 +6,14 @@
 namespace dust {
 namespace distr {
 
-template <typename IntType, typename FloatType, typename RNG>
-IntType binomial_inversion(IntType n, FloatType prob, RNG& generator) {
-  FloatType geom_sum = 0;
-  IntType num_geom = 0;
+template <typename float_t, typename int_t, typename rng_t>
+int_t binomial_inversion(int_t n, float_t prob, rng_t& generator) {
+  float_t geom_sum = 0;
+  int_t num_geom = 0;
 
   while (true) {
-    FloatType r = generator.unif_rand();
-    FloatType geom = std::ceil(std::log(r) / std::log1p(-prob));
+    float_t r = generator.unif_rand();
+    float_t geom = std::ceil(std::log(r) / std::log1p(-prob));
     geom_sum += geom;
     if (geom_sum > n) {
       break;
@@ -23,17 +23,17 @@ IntType binomial_inversion(IntType n, FloatType prob, RNG& generator) {
   return num_geom;
 }
 
-template <typename FloatType>
-FloatType stirling_approx_tail(FloatType k) {
-  static FloatType kTailValues[] = {0.0810614667953272,  0.0413406959554092,
-                                    0.0276779256849983,  0.02079067210376509,
-                                    0.0166446911898211,  0.0138761288230707,
-                                    0.0118967099458917,  0.0104112652619720,
-                                    0.00925546218271273, 0.00833056343336287};
+template <typename float_t>
+float_t stirling_approx_tail(float_t k) {
+  static float_t kTailValues[] = {0.0810614667953272,  0.0413406959554092,
+                                  0.0276779256849983,  0.02079067210376509,
+                                  0.0166446911898211,  0.0138761288230707,
+                                  0.0118967099458917,  0.0104112652619720,
+                                  0.00925546218271273, 0.00833056343336287};
   if (k <= 9) {
     return kTailValues[static_cast<short>(k)];
   }
-  FloatType kp1sq = (k + 1) * (k + 1);
+  float_t kp1sq = (k + 1) * (k + 1);
   return (1.0 / 12 - (1.0 / 360 - 1.0 / 1260 / kp1sq) / kp1sq) / (k + 1);
 }
 
@@ -41,8 +41,8 @@ FloatType stirling_approx_tail(FloatType k) {
 // as an double and k coming out as a double
 //
 // https://www.tandfonline.com/doi/abs/10.1080/00949659308811496
-template <typename RNG>
-inline double btrs(double n, double p, RNG& generator) {
+template <typename rng_t>
+inline double btrs(double n, double p, rng_t& generator) {
   // This is spq in the paper.
   const double stddev = std::sqrt(n * p * (1 - p));
 
@@ -92,9 +92,9 @@ inline double btrs(double n, double p, RNG& generator) {
   }
 }
 
-template <typename IntType, typename FloatType, typename RNG>
-IntType rbinom(RNG& generator, IntType n, FloatType p) {
-  IntType draw;
+template <typename float_t, typename int_t, typename rng_t>
+int_t rbinom(rng_t& generator, int_t n, float_t p) {
+  int_t draw;
 
   // Early exit:
   if (n == 0 || p == 0) {
@@ -107,22 +107,22 @@ IntType rbinom(RNG& generator, IntType n, FloatType p) {
   // TODO: Should control for this too, but not really clear what we
   // need to do to safely deal.
   /*
-  if (n < 0 || p < 0 || p > 1) {
+    if (n < 0 || p < 0 || p > 1) {
     return NaN;
-  }
+    }
   */
 
-  FloatType q = p;
+  float_t q = p;
   if (q > 0.5) {
     q = 1 - q;
   }
 
   if (n * q >= 10) {
     // Uses 256 random numbers
-    draw = static_cast<IntType>(btrs(n, q, generator));
+    draw = static_cast<int_t>(btrs(n, q, generator));
   } else {
     // Uses 42 random numbers
-    draw = static_cast<IntType>(binomial_inversion(n, q, generator));
+    draw = static_cast<int_t>(binomial_inversion(n, q, generator));
   }
 
   if (p > 0.5) {

--- a/inst/include/dust/distr/binomial.hpp
+++ b/inst/include/dust/distr/binomial.hpp
@@ -88,9 +88,9 @@ inline double btrs(double n, double p, RNG& generator) {
   }
 }
 
-template <typename T, typename RNG>
-T rbinom(RNG& generator, int n, double p) {
-  T draw;
+template <typename IntType, typename FloatType, typename RNG>
+IntType rbinom(RNG& generator, IntType n, FloatType p) {
+  IntType draw;
 
   // Early exit:
   if (n == 0 || p == 0) {
@@ -108,17 +108,17 @@ T rbinom(RNG& generator, int n, double p) {
   }
   */
 
-  double q = p;
+  FloatType q = p;
   if (q > 0.5) {
     q = 1 - q;
   }
 
   if (n * q >= 10) {
     // Uses 256 random numbers
-    draw = static_cast<T>(btrs(n, q, generator));
+    draw = static_cast<IntType>(btrs(n, q, generator));
   } else {
     // Uses 42 random numbers
-    draw = static_cast<T>(binomial_inversion(n, q, generator));
+    draw = static_cast<IntType>(binomial_inversion(n, q, generator));
   }
 
   if (p > 0.5) {

--- a/inst/include/dust/distr/binomial.hpp
+++ b/inst/include/dust/distr/binomial.hpp
@@ -112,7 +112,7 @@ int_t rbinom(rng_t& generator, int_t n, real_t p) {
   */
 
   real_t q = p;
-  if (q > 0.5) {
+  if (p > 0.5) {
     q = 1 - q;
   }
 

--- a/inst/include/dust/distr/poisson.hpp
+++ b/inst/include/dust/distr/poisson.hpp
@@ -6,9 +6,9 @@
 namespace dust {
 namespace distr {
 
-template <typename IntType, typename FloatType, typename RNG>
-IntType rpois(RNG& generator, FloatType lambda) {
-  IntType x = 0;
+template <typename float_t, typename int_t, typename rng_t>
+int_t rpois(rng_t& generator, float_t lambda) {
+  int_t x = 0;
   if (lambda < 10) {
     // Knuth's algorithm for generating Poisson random variates.
     // Given a Poisson process, the time between events is exponentially
@@ -18,17 +18,17 @@ IntType rpois(RNG& generator, FloatType lambda) {
     // Thus to simulate a Poisson draw, we can draw X_i ~ Exp(lambda),
     // and N ~ Poisson(lambda), where N is the least number such that
     // \sum_i^N X_i > 1.
-    const FloatType exp_neg_rate = std::exp(-lambda);
+    const float_t exp_neg_rate = std::exp(-lambda);
 
-    FloatType prod = 1;
+    float_t prod = 1;
 
     // Keep trying until we surpass e^(-rate). This will take
     // expected time proportional to rate.
     while (true) {
-      FloatType u = generator.unif_rand();
+      float_t u = generator.unif_rand();
       prod = prod * u;
       if (prod <= exp_neg_rate &&
-          x <= std::numeric_limits<IntType>::max()) {
+          x <= std::numeric_limits<int_t>::max()) {
         break;
       }
       x++;
@@ -56,29 +56,29 @@ IntType rpois(RNG& generator, FloatType lambda) {
     //
     // G(u) = (2 * a / (2 - |u|) + b) * u + c
 
-    const FloatType log_rate = std::log(lambda);
+    const float_t log_rate = std::log(lambda);
 
     // Constants used to define the dominating distribution. Names taken
     // from Hormann's paper. Constants were chosen to define the tightest
     // G(u) for the inverse Poisson CDF.
-    const FloatType b = 0.931 + 2.53 * std::sqrt(lambda);
-    const FloatType a = -0.059 + 0.02483 * b;
+    const float_t b = 0.931 + 2.53 * std::sqrt(lambda);
+    const float_t a = -0.059 + 0.02483 * b;
 
     // This is the inverse acceptance rate. At a minimum (when rate = 10),
     // this corresponds to ~75% acceptance. As the rate becomes larger, this
     // approaches ~89%.
-    const FloatType inv_alpha = 1.1239 + 1.1328 / (b - 3.4);
+    const float_t inv_alpha = 1.1239 + 1.1328 / (b - 3.4);
 
     while (true) {
-      FloatType u = generator.unif_rand();
+      float_t u = generator.unif_rand();
       u -= 0.5;
-      FloatType v = generator.unif_rand();
+      float_t v = generator.unif_rand();
 
-      FloatType u_shifted = 0.5 - std::fabs(u);
-      IntType k = floor((2 * a / u_shifted + b) * u + lambda +
-                  0.43);
+      float_t u_shifted = 0.5 - std::fabs(u);
+      int_t k = floor((2 * a / u_shifted + b) * u + lambda +
+                      0.43);
 
-      if (k > std::numeric_limits<IntType>::max()) {
+      if (k > std::numeric_limits<int_t>::max()) {
         // retry in case of overflow.
         continue; // # nocov
       }
@@ -99,8 +99,8 @@ IntType rpois(RNG& generator, FloatType lambda) {
 
       // The expression below is equivalent to the computation of step 2)
       // in transformed rejection (v <= alpha * F'(G(u)) * G'(u)).
-      FloatType s = std::log(v * inv_alpha / (a / (u_shifted * u_shifted) + b));
-      FloatType t = -lambda + k * log_rate - std::lgamma(k + 1);
+      float_t s = std::log(v * inv_alpha / (a / (u_shifted * u_shifted) + b));
+      float_t t = -lambda + k * log_rate - std::lgamma(k + 1);
       if (s <= t) {
         x = k;
         break;

--- a/inst/include/dust/distr/poisson.hpp
+++ b/inst/include/dust/distr/poisson.hpp
@@ -6,8 +6,8 @@
 namespace dust {
 namespace distr {
 
-template <typename float_t, typename int_t, typename rng_t>
-int_t rpois(rng_t& generator, float_t lambda) {
+template <typename real_t, typename int_t, typename rng_t>
+int_t rpois(rng_t& generator, real_t lambda) {
   int_t x = 0;
   if (lambda < 10) {
     // Knuth's algorithm for generating Poisson random variates.
@@ -18,14 +18,14 @@ int_t rpois(rng_t& generator, float_t lambda) {
     // Thus to simulate a Poisson draw, we can draw X_i ~ Exp(lambda),
     // and N ~ Poisson(lambda), where N is the least number such that
     // \sum_i^N X_i > 1.
-    const float_t exp_neg_rate = std::exp(-lambda);
+    const real_t exp_neg_rate = std::exp(-lambda);
 
-    float_t prod = 1;
+    real_t prod = 1;
 
     // Keep trying until we surpass e^(-rate). This will take
     // expected time proportional to rate.
     while (true) {
-      float_t u = generator.unif_rand();
+      real_t u = generator.unif_rand();
       prod = prod * u;
       if (prod <= exp_neg_rate &&
           x <= std::numeric_limits<int_t>::max()) {
@@ -56,25 +56,25 @@ int_t rpois(rng_t& generator, float_t lambda) {
     //
     // G(u) = (2 * a / (2 - |u|) + b) * u + c
 
-    const float_t log_rate = std::log(lambda);
+    const real_t log_rate = std::log(lambda);
 
     // Constants used to define the dominating distribution. Names taken
     // from Hormann's paper. Constants were chosen to define the tightest
     // G(u) for the inverse Poisson CDF.
-    const float_t b = 0.931 + 2.53 * std::sqrt(lambda);
-    const float_t a = -0.059 + 0.02483 * b;
+    const real_t b = 0.931 + 2.53 * std::sqrt(lambda);
+    const real_t a = -0.059 + 0.02483 * b;
 
     // This is the inverse acceptance rate. At a minimum (when rate = 10),
     // this corresponds to ~75% acceptance. As the rate becomes larger, this
     // approaches ~89%.
-    const float_t inv_alpha = 1.1239 + 1.1328 / (b - 3.4);
+    const real_t inv_alpha = 1.1239 + 1.1328 / (b - 3.4);
 
     while (true) {
-      float_t u = generator.unif_rand();
+      real_t u = generator.unif_rand();
       u -= 0.5;
-      float_t v = generator.unif_rand();
+      real_t v = generator.unif_rand();
 
-      float_t u_shifted = 0.5 - std::fabs(u);
+      real_t u_shifted = 0.5 - std::fabs(u);
       int_t k = floor((2 * a / u_shifted + b) * u + lambda +
                       0.43);
 
@@ -99,8 +99,8 @@ int_t rpois(rng_t& generator, float_t lambda) {
 
       // The expression below is equivalent to the computation of step 2)
       // in transformed rejection (v <= alpha * F'(G(u)) * G'(u)).
-      float_t s = std::log(v * inv_alpha / (a / (u_shifted * u_shifted) + b));
-      float_t t = -lambda + k * log_rate - std::lgamma(k + 1);
+      real_t s = std::log(v * inv_alpha / (a / (u_shifted * u_shifted) + b));
+      real_t t = -lambda + k * log_rate - std::lgamma(k + 1);
       if (s <= t) {
         x = k;
         break;

--- a/inst/include/dust/distr/poisson.hpp
+++ b/inst/include/dust/distr/poisson.hpp
@@ -6,9 +6,9 @@
 namespace dust {
 namespace distr {
 
-template <typename IntegerType, typename FloatType, typename RNG>
-IntegerType rpois(RNG& generator, FloatType lambda) {
-  IntegerType x = 0;
+template <typename IntType, typename FloatType, typename RNG>
+IntType rpois(RNG& generator, FloatType lambda) {
+  IntType x = 0;
   if (lambda < 10) {
     // Knuth's algorithm for generating Poisson random variates.
     // Given a Poisson process, the time between events is exponentially
@@ -28,7 +28,7 @@ IntegerType rpois(RNG& generator, FloatType lambda) {
       FloatType u = generator.unif_rand();
       prod = prod * u;
       if (prod <= exp_neg_rate &&
-          x <= std::numeric_limits<IntegerType>::max()) {
+          x <= std::numeric_limits<IntType>::max()) {
         break;
       }
       x++;
@@ -75,10 +75,10 @@ IntegerType rpois(RNG& generator, FloatType lambda) {
       FloatType v = generator.unif_rand();
 
       FloatType u_shifted = 0.5 - std::fabs(u);
-      IntegerType k = floor((2 * a / u_shifted + b) * u + lambda +
+      IntType k = floor((2 * a / u_shifted + b) * u + lambda +
                   0.43);
 
-      if (k > std::numeric_limits<IntegerType>::max()) {
+      if (k > std::numeric_limits<IntType>::max()) {
         // retry in case of overflow.
         continue; // # nocov
       }

--- a/inst/include/dust/distr/poisson.hpp
+++ b/inst/include/dust/distr/poisson.hpp
@@ -6,9 +6,9 @@
 namespace dust {
 namespace distr {
 
-template <class T, typename RNG>
-T rpois(RNG& generator, double lambda) {
-  T x = 0;
+template <typename IntegerType, typename FloatType, typename RNG>
+IntegerType rpois(RNG& generator, FloatType lambda) {
+  IntegerType x = 0;
   if (lambda < 10) {
     // Knuth's algorithm for generating Poisson random variates.
     // Given a Poisson process, the time between events is exponentially
@@ -18,17 +18,17 @@ T rpois(RNG& generator, double lambda) {
     // Thus to simulate a Poisson draw, we can draw X_i ~ Exp(lambda),
     // and N ~ Poisson(lambda), where N is the least number such that
     // \sum_i^N X_i > 1.
-    const double exp_neg_rate = std::exp(-lambda);
+    const FloatType exp_neg_rate = std::exp(-lambda);
 
-    double prod = 1;
+    FloatType prod = 1;
 
     // Keep trying until we surpass e^(-rate). This will take
     // expected time proportional to rate.
     while (true) {
-      double u = generator.unif_rand();
+      FloatType u = generator.unif_rand();
       prod = prod * u;
       if (prod <= exp_neg_rate &&
-          x <= std::numeric_limits<T>::max()) {
+          x <= std::numeric_limits<IntegerType>::max()) {
         break;
       }
       x++;
@@ -56,29 +56,29 @@ T rpois(RNG& generator, double lambda) {
     //
     // G(u) = (2 * a / (2 - |u|) + b) * u + c
 
-    const double log_rate = std::log(lambda);
+    const FloatType log_rate = std::log(lambda);
 
     // Constants used to define the dominating distribution. Names taken
     // from Hormann's paper. Constants were chosen to define the tightest
     // G(u) for the inverse Poisson CDF.
-    const double b = 0.931 + 2.53 * std::sqrt(lambda);
-    const double a = -0.059 + 0.02483 * b;
+    const FloatType b = 0.931 + 2.53 * std::sqrt(lambda);
+    const FloatType a = -0.059 + 0.02483 * b;
 
     // This is the inverse acceptance rate. At a minimum (when rate = 10),
     // this corresponds to ~75% acceptance. As the rate becomes larger, this
     // approaches ~89%.
-    const double inv_alpha = 1.1239 + 1.1328 / (b - 3.4);
+    const FloatType inv_alpha = 1.1239 + 1.1328 / (b - 3.4);
 
     while (true) {
-      double u = generator.unif_rand();
+      FloatType u = generator.unif_rand();
       u -= 0.5;
-      double v = generator.unif_rand();
+      FloatType v = generator.unif_rand();
 
-      double u_shifted = 0.5 - std::fabs(u);
-      T k = floor((2 * a / u_shifted + b) * u + lambda +
+      FloatType u_shifted = 0.5 - std::fabs(u);
+      IntegerType k = floor((2 * a / u_shifted + b) * u + lambda +
                   0.43);
 
-      if (k > std::numeric_limits<T>::max()) {
+      if (k > std::numeric_limits<IntegerType>::max()) {
         // retry in case of overflow.
         continue; // # nocov
       }
@@ -99,8 +99,8 @@ T rpois(RNG& generator, double lambda) {
 
       // The expression below is equivalent to the computation of step 2)
       // in transformed rejection (v <= alpha * F'(G(u)) * G'(u)).
-      double s = std::log(v * inv_alpha / (a / (u_shifted * u_shifted) + b));
-      double t = -lambda + k * log_rate - std::lgamma(k + 1);
+      FloatType s = std::log(v * inv_alpha / (a / (u_shifted * u_shifted) + b));
+      FloatType t = -lambda + k * log_rate - std::lgamma(k + 1);
       if (s <= t) {
         x = k;
         break;

--- a/inst/include/dust/dust.hpp
+++ b/inst/include/dust/dust.hpp
@@ -13,8 +13,8 @@ class Particle {
 public:
   typedef typename T::init_t init_t;
   typedef typename T::int_t int_t;
-  typedef typename T::dust_t dust_t;
-  typedef typename dust::RNG<dust_t, int_t> rng_t;
+  typedef typename T::real_t real_t;
+  typedef typename dust::RNG<real_t, int_t> rng_t;
 
   Particle(init_t data, size_t step) :
     _model(data),
@@ -32,13 +32,13 @@ public:
   }
 
   void state(const std::vector<size_t>& index_y,
-             typename std::vector<dust_t>::iterator end_state) const {
+             typename std::vector<real_t>::iterator end_state) const {
     for (size_t i = 0; i < index_y.size(); ++i) {
       *(end_state + i) = _y[index_y[i]];
     }
   }
 
-  void state(typename std::vector<dust_t>::iterator end_state) const {
+  void state(typename std::vector<real_t>::iterator end_state) const {
     for (size_t i = 0; i < _y.size(); ++i) {
       *(end_state + i) = _y[i];
     }
@@ -64,8 +64,8 @@ private:
   T _model;
   size_t _step;
 
-  std::vector<dust_t> _y;
-  std::vector<dust_t> _y_swap;
+  std::vector<real_t> _y;
+  std::vector<real_t> _y_swap;
 };
 
 template <typename T>
@@ -73,8 +73,8 @@ class Dust {
 public:
   typedef typename T::init_t init_t;
   typedef typename T::int_t int_t;
-  typedef typename T::dust_t dust_t;
-  typedef typename dust::RNG<dust_t, int_t> rng_t;
+  typedef typename T::real_t real_t;
+  typedef typename dust::RNG<real_t, int_t> rng_t;
 
   Dust(const init_t data, const size_t step,
        const std::vector<size_t> index_y,
@@ -112,14 +112,14 @@ public:
     }
   }
 
-  void state(std::vector<dust_t>& end_state) const {
+  void state(std::vector<real_t>& end_state) const {
     #pragma omp parallel for schedule(static) num_threads(_n_threads)
     for (size_t i = 0; i < _particles.size(); ++i) {
       _particles[i].state(_index_y, end_state.begin() + i * _index_y.size());
     }
   }
 
-  void state_full(std::vector<dust_t>& end_state) const {
+  void state_full(std::vector<real_t>& end_state) const {
     const size_t n = n_state_full();
     #pragma omp parallel for schedule(static) num_threads(_n_threads)
     for (size_t i = 0; i < _particles.size(); ++i) {
@@ -166,7 +166,7 @@ public:
 private:
   const std::vector<size_t> _index_y;
   const size_t _n_threads;
-  dust::pRNG<dust_t, int_t> _rng;
+  dust::pRNG<real_t, int_t> _rng;
   std::vector<Particle<T>> _particles;
 
   // This scheme means that if we have the same number of generators

--- a/inst/include/dust/dust.hpp
+++ b/inst/include/dust/dust.hpp
@@ -14,6 +14,7 @@ public:
   typedef typename T::init_t init_t;
   typedef typename T::int_t int_t;
   typedef typename T::float_t float_t;
+  typedef typename dust::RNG<float_t, int_t> rng_t;
 
   Particle(init_t data, size_t step) :
     _model(data),
@@ -22,7 +23,7 @@ public:
     _y_swap(_model.size()) {
   }
 
-  void run(const size_t step_end, dust::RNG<float_t, int_t>& rng) {
+  void run(const size_t step_end, rng_t& rng) {
     while (_step < step_end) {
       _model.update(_step, _y, rng, _y_swap);
       _step++;
@@ -73,6 +74,7 @@ public:
   typedef typename T::init_t init_t;
   typedef typename T::int_t int_t;
   typedef typename T::float_t float_t;
+  typedef typename dust::RNG<float_t, int_t> rng_t;
 
   Dust(const init_t data, const size_t step,
        const std::vector<size_t> index_y,
@@ -187,8 +189,7 @@ private:
   //   thread 2: 2 3 2 3 2 3 2 3 2 3 2 3 2 3 2 3 2 3 2 3 2 3 2 3 2
   //   thread 3: 4 5 4 5 4 5 4 5 4 5 4 5 4 5 4 5 4 5 4 5 4 5 4 5 4
   //   thread 4: 6 7 6 7 6 7 6 7 6 7 6 7 6 7 6 7 6 7 6 7 6 7 6 7 6
-  dust::RNG<float_t, int_t>& pick_generator(const size_t i,
-                                            const size_t thread_idx) {
+  rng_t& pick_generator(const size_t i, const size_t thread_idx) {
     const size_t m = _rng.size() / _n_threads;
     return _rng(i % m + thread_idx * m);
   }

--- a/inst/include/dust/dust.hpp
+++ b/inst/include/dust/dust.hpp
@@ -19,7 +19,7 @@ public:
     _y_swap(_model.size()) {
   }
 
-  void run(const size_t step_end, dust::RNG& rng) {
+  void run(const size_t step_end, dust::RNG<double, int>& rng) {
     while (_step < step_end) {
       _model.update(_step, _y, rng, _y_swap);
       _step++;
@@ -158,7 +158,7 @@ public:
 private:
   const std::vector<size_t> _index_y;
   const size_t _n_threads;
-  dust::pRNG _rng;
+  dust::pRNG<double, int> _rng;
   std::vector<Particle<T>> _particles;
 
   // This scheme means that if we have the same number of generators
@@ -181,7 +181,8 @@ private:
   //   thread 2: 2 3 2 3 2 3 2 3 2 3 2 3 2 3 2 3 2 3 2 3 2 3 2 3 2
   //   thread 3: 4 5 4 5 4 5 4 5 4 5 4 5 4 5 4 5 4 5 4 5 4 5 4 5 4
   //   thread 4: 6 7 6 7 6 7 6 7 6 7 6 7 6 7 6 7 6 7 6 7 6 7 6 7 6
-  dust::RNG& pick_generator(const size_t i, const size_t thread_idx) {
+  dust::RNG<double, int>& pick_generator(const size_t i,
+                                         const size_t thread_idx) {
     const size_t m = _rng.size() / _n_threads;
     return _rng(i % m + thread_idx * m);
   }

--- a/inst/include/dust/dust.hpp
+++ b/inst/include/dust/dust.hpp
@@ -13,8 +13,8 @@ class Particle {
 public:
   typedef typename T::init_t init_t;
   typedef typename T::int_t int_t;
-  typedef typename T::float_t float_t;
-  typedef typename dust::RNG<float_t, int_t> rng_t;
+  typedef typename T::dust_t dust_t;
+  typedef typename dust::RNG<dust_t, int_t> rng_t;
 
   Particle(init_t data, size_t step) :
     _model(data),
@@ -32,13 +32,13 @@ public:
   }
 
   void state(const std::vector<size_t>& index_y,
-             typename std::vector<float_t>::iterator end_state) const {
+             typename std::vector<dust_t>::iterator end_state) const {
     for (size_t i = 0; i < index_y.size(); ++i) {
       *(end_state + i) = _y[index_y[i]];
     }
   }
 
-  void state(typename std::vector<float_t>::iterator end_state) const {
+  void state(typename std::vector<dust_t>::iterator end_state) const {
     for (size_t i = 0; i < _y.size(); ++i) {
       *(end_state + i) = _y[i];
     }
@@ -64,8 +64,8 @@ private:
   T _model;
   size_t _step;
 
-  std::vector<float_t> _y;
-  std::vector<float_t> _y_swap;
+  std::vector<dust_t> _y;
+  std::vector<dust_t> _y_swap;
 };
 
 template <typename T>
@@ -73,8 +73,8 @@ class Dust {
 public:
   typedef typename T::init_t init_t;
   typedef typename T::int_t int_t;
-  typedef typename T::float_t float_t;
-  typedef typename dust::RNG<float_t, int_t> rng_t;
+  typedef typename T::dust_t dust_t;
+  typedef typename dust::RNG<dust_t, int_t> rng_t;
 
   Dust(const init_t data, const size_t step,
        const std::vector<size_t> index_y,
@@ -112,14 +112,14 @@ public:
     }
   }
 
-  void state(std::vector<float_t>& end_state) const {
+  void state(std::vector<dust_t>& end_state) const {
     #pragma omp parallel for schedule(static) num_threads(_n_threads)
     for (size_t i = 0; i < _particles.size(); ++i) {
       _particles[i].state(_index_y, end_state.begin() + i * _index_y.size());
     }
   }
 
-  void state_full(std::vector<float_t>& end_state) const {
+  void state_full(std::vector<dust_t>& end_state) const {
     const size_t n = n_state_full();
     #pragma omp parallel for schedule(static) num_threads(_n_threads)
     for (size_t i = 0; i < _particles.size(); ++i) {
@@ -166,7 +166,7 @@ public:
 private:
   const std::vector<size_t> _index_y;
   const size_t _n_threads;
-  dust::pRNG<float_t, int_t> _rng;
+  dust::pRNG<dust_t, int_t> _rng;
   std::vector<Particle<T>> _particles;
 
   // This scheme means that if we have the same number of generators

--- a/inst/include/dust/interface.hpp
+++ b/inst/include/dust/interface.hpp
@@ -39,7 +39,7 @@ Rcpp::NumericMatrix dust_run(SEXP ptr, int step_end) {
   const size_t n_particles = obj->n_particles();
   const size_t len = n_state * n_particles;
 
-  std::vector<typename T::float_t> dat(len);
+  std::vector<typename T::real_t> dat(len);
   obj->state(dat);
 
   return Rcpp::NumericMatrix(n_state, n_particles, dat.begin());
@@ -61,7 +61,7 @@ SEXP dust_state(SEXP ptr) {
   const size_t n_particles = obj->n_particles();
   const size_t len = n_state_full * n_particles;
 
-  std::vector<typename T::float_t> dat(len);
+  std::vector<typename T::real_t> dat(len);
   obj->state_full(dat);
 
   return Rcpp::NumericMatrix(n_state_full, n_particles, dat.begin());

--- a/inst/include/dust/interface.hpp
+++ b/inst/include/dust/interface.hpp
@@ -39,7 +39,7 @@ Rcpp::NumericMatrix dust_run(SEXP ptr, int step_end) {
   const size_t n_particles = obj->n_particles();
   const size_t len = n_state * n_particles;
 
-  std::vector<double> dat(len);
+  std::vector<typename T::float_t> dat(len);
   obj->state(dat);
 
   return Rcpp::NumericMatrix(n_state, n_particles, dat.begin());
@@ -61,7 +61,7 @@ SEXP dust_state(SEXP ptr) {
   const size_t n_particles = obj->n_particles();
   const size_t len = n_state_full * n_particles;
 
-  std::vector<double> dat(len);
+  std::vector<typename T::float_t> dat(len);
   obj->state_full(dat);
 
   return Rcpp::NumericMatrix(n_state_full, n_particles, dat.begin());

--- a/inst/include/dust/rng.hpp
+++ b/inst/include/dust/rng.hpp
@@ -10,7 +10,7 @@ namespace dust {
 
 class RNG {
 public:
-  RNG(dust::Xoshiro generator) : _generator(generator) {}
+  RNG(dust::Xoshiro<double> generator) : _generator(generator) {}
 
   double unif_rand() {
     return _generator.unif_rand();
@@ -35,14 +35,14 @@ public:
   }
 
 private:
-  dust::Xoshiro _generator;
+  dust::Xoshiro<double> _generator;
 };
 
 
 class pRNG {
 public:
   pRNG(const size_t n, const uint64_t seed) {
-    dust::Xoshiro rng(seed);
+    dust::Xoshiro<double> rng(seed);
     for (size_t i = 0; i < n; ++i) {
       _rngs.push_back(RNG(rng));
       rng.jump();

--- a/inst/include/dust/rng.hpp
+++ b/inst/include/dust/rng.hpp
@@ -8,50 +8,50 @@
 
 namespace dust {
 
+template <typename FloatType, typename IntType>
 class RNG {
 public:
-  RNG(dust::Xoshiro<double> generator) : _generator(generator) {}
+  RNG(dust::Xoshiro<FloatType> generator) : _generator(generator) {}
 
-  double unif_rand() {
+  FloatType unif_rand() {
     return _generator.unif_rand();
   }
 
-  double runif(double min, double max) {
-    std::uniform_real_distribution<double> unif_dist(min, max);
+  FloatType runif(FloatType min, FloatType max) {
+    std::uniform_real_distribution<FloatType> unif_dist(min, max);
     return unif_dist(_generator);
   }
 
-  double rnorm(double mu, double sd) {
-    std::normal_distribution<double> norm(mu, sd);
+  FloatType rnorm(FloatType mu, FloatType sd) {
+    std::normal_distribution<FloatType> norm(mu, sd);
     return norm(_generator);
   }
 
-  template <typename IntType = int, typename FloatType = double>
   IntType rbinom(IntType n, FloatType p) {
     return dust::distr::rbinom(_generator, n, p);
   }
 
-  template <typename IntType = int, typename FloatType = double>
   IntType rpois(FloatType lambda) {
     return dust::distr::rpois<IntType>(_generator, lambda);
   }
 
 private:
-  dust::Xoshiro<double> _generator;
+  dust::Xoshiro<FloatType> _generator;
 };
 
 
+template <typename FloatType, typename IntType>
 class pRNG {
 public:
   pRNG(const size_t n, const uint64_t seed) {
-    dust::Xoshiro<double> rng(seed);
+    dust::Xoshiro<FloatType> rng(seed);
     for (size_t i = 0; i < n; ++i) {
-      _rngs.push_back(RNG(rng));
+      _rngs.push_back(RNG<FloatType, IntType>(rng));
       rng.jump();
     }
   }
 
-  RNG& operator()(size_t index) {
+  RNG<FloatType, IntType>& operator()(size_t index) {
     return _rngs[index];
   }
 
@@ -60,7 +60,7 @@ public:
   }
 
 private:
-  std::vector<RNG> _rngs;
+  std::vector<RNG<FloatType, IntType>> _rngs;
 };
 
 }

--- a/inst/include/dust/rng.hpp
+++ b/inst/include/dust/rng.hpp
@@ -8,50 +8,50 @@
 
 namespace dust {
 
-template <typename FloatType = double, typename IntType = int>
+template <typename float_t, typename int_t>
 class RNG {
 public:
-  RNG(dust::Xoshiro<FloatType> generator) : _generator(generator) {}
+  RNG(dust::Xoshiro<float_t> generator) : _generator(generator) {}
 
-  FloatType unif_rand() {
+  float_t unif_rand() {
     return _generator.unif_rand();
   }
 
-  FloatType runif(FloatType min, FloatType max) {
-    std::uniform_real_distribution<FloatType> unif_dist(min, max);
+  float_t runif(float_t min, float_t max) {
+    std::uniform_real_distribution<float_t> unif_dist(min, max);
     return unif_dist(_generator);
   }
 
-  FloatType rnorm(FloatType mu, FloatType sd) {
-    std::normal_distribution<FloatType> norm(mu, sd);
+  float_t rnorm(float_t mu, float_t sd) {
+    std::normal_distribution<float_t> norm(mu, sd);
     return norm(_generator);
   }
 
-  IntType rbinom(IntType n, FloatType p) {
-    return dust::distr::rbinom(_generator, n, p);
+  int_t rbinom(int_t n, float_t p) {
+    return dust::distr::rbinom<float_t, int_t>(_generator, n, p);
   }
 
-  IntType rpois(FloatType lambda) {
-    return dust::distr::rpois<IntType>(_generator, lambda);
+  int_t rpois(float_t lambda) {
+    return dust::distr::rpois<float_t, int_t>(_generator, lambda);
   }
 
 private:
-  dust::Xoshiro<FloatType> _generator;
+  dust::Xoshiro<float_t> _generator;
 };
 
 
-template <typename FloatType, typename IntType>
+template <typename float_t, typename int_t>
 class pRNG {
 public:
   pRNG(const size_t n, const uint64_t seed) {
-    dust::Xoshiro<FloatType> rng(seed);
+    dust::Xoshiro<float_t> rng(seed);
     for (size_t i = 0; i < n; ++i) {
-      _rngs.push_back(RNG<FloatType, IntType>(rng));
+      _rngs.push_back(RNG<float_t, int_t>(rng));
       rng.jump();
     }
   }
 
-  RNG<FloatType, IntType>& operator()(size_t index) {
+  RNG<float_t, int_t>& operator()(size_t index) {
     return _rngs[index];
   }
 
@@ -60,7 +60,7 @@ public:
   }
 
 private:
-  std::vector<RNG<FloatType, IntType>> _rngs;
+  std::vector<RNG<float_t, int_t>> _rngs;
 };
 
 }

--- a/inst/include/dust/rng.hpp
+++ b/inst/include/dust/rng.hpp
@@ -30,8 +30,9 @@ public:
     return dust::distr::rbinom<T>(_generator, n, p);
   }
 
-  template <class T = int> T rpois(double lambda) {
-    return dust::distr::rpois<T>(_generator, lambda);
+  template <typename IntType = int, typename FloatType = double>
+  IntType rpois(FloatType lambda) {
+    return dust::distr::rpois<IntType, FloatType>(_generator, lambda);
   }
 
 private:

--- a/inst/include/dust/rng.hpp
+++ b/inst/include/dust/rng.hpp
@@ -8,50 +8,50 @@
 
 namespace dust {
 
-template <typename float_t, typename int_t>
+template <typename real_t, typename int_t>
 class RNG {
 public:
-  RNG(dust::Xoshiro<float_t> generator) : _generator(generator) {}
+  RNG(dust::Xoshiro<real_t> generator) : _generator(generator) {}
 
-  float_t unif_rand() {
+  real_t unif_rand() {
     return _generator.unif_rand();
   }
 
-  float_t runif(float_t min, float_t max) {
-    std::uniform_real_distribution<float_t> unif_dist(min, max);
+  real_t runif(real_t min, real_t max) {
+    std::uniform_real_distribution<real_t> unif_dist(min, max);
     return unif_dist(_generator);
   }
 
-  float_t rnorm(float_t mu, float_t sd) {
-    std::normal_distribution<float_t> norm(mu, sd);
+  real_t rnorm(real_t mu, real_t sd) {
+    std::normal_distribution<real_t> norm(mu, sd);
     return norm(_generator);
   }
 
-  int_t rbinom(int_t n, float_t p) {
-    return dust::distr::rbinom<float_t, int_t>(_generator, n, p);
+  int_t rbinom(int_t n, real_t p) {
+    return dust::distr::rbinom<real_t, int_t>(_generator, n, p);
   }
 
-  int_t rpois(float_t lambda) {
-    return dust::distr::rpois<float_t, int_t>(_generator, lambda);
+  int_t rpois(real_t lambda) {
+    return dust::distr::rpois<real_t, int_t>(_generator, lambda);
   }
 
 private:
-  dust::Xoshiro<float_t> _generator;
+  dust::Xoshiro<real_t> _generator;
 };
 
 
-template <typename float_t, typename int_t>
+template <typename real_t, typename int_t>
 class pRNG {
 public:
   pRNG(const size_t n, const uint64_t seed) {
-    dust::Xoshiro<float_t> rng(seed);
+    dust::Xoshiro<real_t> rng(seed);
     for (size_t i = 0; i < n; ++i) {
-      _rngs.push_back(RNG<float_t, int_t>(rng));
+      _rngs.push_back(RNG<real_t, int_t>(rng));
       rng.jump();
     }
   }
 
-  RNG<float_t, int_t>& operator()(size_t index) {
+  RNG<real_t, int_t>& operator()(size_t index) {
     return _rngs[index];
   }
 
@@ -60,7 +60,7 @@ public:
   }
 
 private:
-  std::vector<RNG<float_t, int_t>> _rngs;
+  std::vector<RNG<real_t, int_t>> _rngs;
 };
 
 }

--- a/inst/include/dust/rng.hpp
+++ b/inst/include/dust/rng.hpp
@@ -8,7 +8,7 @@
 
 namespace dust {
 
-template <typename FloatType, typename IntType>
+template <typename FloatType = double, typename IntType = int>
 class RNG {
 public:
   RNG(dust::Xoshiro<FloatType> generator) : _generator(generator) {}

--- a/inst/include/dust/rng.hpp
+++ b/inst/include/dust/rng.hpp
@@ -26,13 +26,14 @@ public:
     return norm(_generator);
   }
 
-  template <class T = int> T rbinom(int n, double p) {
-    return dust::distr::rbinom<T>(_generator, n, p);
+  template <typename IntType = int, typename FloatType = double>
+  IntType rbinom(IntType n, FloatType p) {
+    return dust::distr::rbinom(_generator, n, p);
   }
 
   template <typename IntType = int, typename FloatType = double>
   IntType rpois(FloatType lambda) {
-    return dust::distr::rpois<IntType, FloatType>(_generator, lambda);
+    return dust::distr::rpois<IntType>(_generator, lambda);
   }
 
 private:

--- a/inst/include/dust/xoshiro.hpp
+++ b/inst/include/dust/xoshiro.hpp
@@ -30,7 +30,7 @@ public:
   }
   uint64_t operator()();
 
-  double unif_rand() {
+  T unif_rand() {
     static std::uniform_real_distribution<T> unif_dist(0, 1);
     return unif_dist(*this);
   }

--- a/inst/include/dust/xoshiro.hpp
+++ b/inst/include/dust/xoshiro.hpp
@@ -17,6 +17,7 @@
 
 namespace dust {
 
+template <typename T>
 class Xoshiro {
 public:
   // Definitions to satisfy interface of URNG in C++11
@@ -30,7 +31,7 @@ public:
   uint64_t operator()();
 
   double unif_rand() {
-    static std::uniform_real_distribution<double> unif_dist(0, 1);
+    static std::uniform_real_distribution<T> unif_dist(0, 1);
     return unif_dist(*this);
   }
 
@@ -50,18 +51,21 @@ static inline uint64_t rotl(const uint64_t x, int k) {
 	return (x << k) | (x >> (64 - k));
 }
 
-inline uint64_t Xoshiro::splitmix64(uint64_t seed) {
+template <typename T>
+inline uint64_t Xoshiro<T>::splitmix64(uint64_t seed) {
   uint64_t z = (seed += 0x9e3779b97f4a7c15);
   z = (z ^ (z >> 30)) * 0xbf58476d1ce4e5b9;
   z = (z ^ (z >> 27)) * 0x94d049bb133111eb;
   return z ^ (z >> 31);
 }
 
-inline Xoshiro::Xoshiro(uint64_t seed) {
+template <typename T>
+inline Xoshiro<T>::Xoshiro(uint64_t seed) {
   set_seed(seed);
 }
 
-inline void Xoshiro::set_seed(uint64_t seed) {
+template <typename T>
+inline void Xoshiro<T>::set_seed(uint64_t seed) {
   // normal brain: for i in 1:4
   // advanced brain: -funroll-loops
   // galaxy brain:
@@ -71,7 +75,8 @@ inline void Xoshiro::set_seed(uint64_t seed) {
   _state[3] = splitmix64(_state[2]);
 }
 
-inline uint64_t Xoshiro::operator()() {
+template <typename T>
+inline uint64_t Xoshiro<T>::operator()() {
   const uint64_t result = rotl(_state[1] * 5, 7) * 9;
 
   const uint64_t t = _state[1] << 17;
@@ -91,7 +96,8 @@ inline uint64_t Xoshiro::operator()() {
 /* This is the jump function for the generator. It is equivalent
    to 2^128 calls to next(); it can be used to generate 2^128
    non-overlapping subsequences for parallel computations. */
-inline void Xoshiro::jump() {
+template <typename T>
+inline void Xoshiro<T>::jump() {
   static const uint64_t JUMP[] = \
     { 0x180ec6d33cfd0aba, 0xd5a61266f0c9392c, 0xa9582618e03fc9aa, 0x39abdc4529b1661c };
 
@@ -121,7 +127,8 @@ inline void Xoshiro::jump() {
    2^192 calls to next(); it can be used to generate 2^64 starting points,
    from each of which jump() will generate 2^64 non-overlapping
    subsequences for parallel distributed computations. */
-inline void Xoshiro::long_jump() {
+template <typename T>
+inline void Xoshiro<T>::long_jump() {
   static const uint64_t LONG_JUMP[] = \
     { 0x76e15d3efefdcbbf, 0xc5004e441c522fb3, 0x77710069854ee241, 0x39109bb02acbe635 };
 

--- a/man/dust.Rd
+++ b/man/dust.Rd
@@ -42,20 +42,24 @@ assumed to be the class name)
 \item That class must define a type \code{init_t} (so \code{model::init_t}) that
 contains its internal data and the model must be constructable
 with a const reference to this type (\verb{const model::init_t& data})
+\item That class must also include typedefs that describe the standard
+floating point and integer types (\code{float_t} and \code{int_t}
+respectively). Most models can include \verb{typedef double float_t;}
+and \verb{typedef int int_t;} in their public section.
 \item The model must have a method \code{size()} returning \code{size_t} which
 returns the size of the system. This size may depend on values
 in your initialisation object but is constant within a model
 run.
 \item The model must have a method \code{update} (which may not be
 \code{const}), taking a step number (\code{size_t}) and returning a
-\verb{std::vector<double>} of initial state for the model.
+\verb{std::vector<float_t>} of initial state for the model.
 \item The model must have a method \code{update} taking arguments:
 \itemize{
 \item \verb{size_t step}: the step number
-\item \verb{const std::vector<double>& state}: the state at the beginning of the
+\item \verb{const std::vector<float_t>& state}: the state at the beginning of the
 step
-\item \code{dust::RNG& rng}: the dust random number generator
-\item \verb{std::vector<double>& state_next}: the end state of the model
+\item \verb{dust::RNG<float_t, int_t>& rng}: the dust random number generator
+\item \verb{std::vector<float_t>& state_next}: the end state of the model
 (to be written to by your function)
 }
 }

--- a/man/dust.Rd
+++ b/man/dust.Rd
@@ -43,8 +43,8 @@ assumed to be the class name)
 contains its internal data and the model must be constructable
 with a const reference to this type (\verb{const model::init_t& data})
 \item That class must also include typedefs that describe the standard
-floating point and integer types (\code{float_t} and \code{int_t}
-respectively). Most models can include \verb{typedef double float_t;}
+floating point and integer types (\code{real_t} and \code{int_t}
+respectively). Most models can include \verb{typedef double real_t;}
 and \verb{typedef int int_t;} in their public section.
 \item The model must have a method \code{size()} returning \code{size_t} which
 returns the size of the system. This size may depend on values
@@ -52,14 +52,14 @@ in your initialisation object but is constant within a model
 run.
 \item The model must have a method \code{update} (which may not be
 \code{const}), taking a step number (\code{size_t}) and returning a
-\verb{std::vector<float_t>} of initial state for the model.
+\verb{std::vector<real_t>} of initial state for the model.
 \item The model must have a method \code{update} taking arguments:
 \itemize{
 \item \verb{size_t step}: the step number
-\item \verb{const std::vector<float_t>& state}: the state at the beginning of the
+\item \verb{const std::vector<real_t>& state}: the state at the beginning of the
 step
-\item \verb{dust::RNG<float_t, int_t>& rng}: the dust random number generator
-\item \verb{std::vector<float_t>& state_next}: the end state of the model
+\item \verb{dust::RNG<real_t, int_t>& rng}: the dust random number generator
+\item \verb{std::vector<real_t>& state_next}: the end state of the model
 (to be written to by your function)
 }
 }

--- a/src/test_rng.cpp
+++ b/src/test_rng.cpp
@@ -5,7 +5,7 @@
 Rcpp::NumericVector test_rng_norm(int n, int seed, int n_generators) {
   const double mean = 0, sd = 1;
 
-  dust::pRNG r(n_generators, seed);
+  dust::pRNG<double, int> r(n_generators, seed);
 
   Rcpp::NumericVector y(n);
   for (int i = 0; i < n; ++i) {
@@ -21,11 +21,11 @@ Rcpp::NumericVector test_rng_unif(int n, double min, double max, int seed,
   bool std_unif =
     Rcpp::traits::is_na<REALSXP>(min) || Rcpp::traits::is_na<REALSXP>(max);
 
-  dust::pRNG r(n_generators, seed);
+  dust::pRNG<double, int> r(n_generators, seed);
   Rcpp::NumericVector y(n);
 
   for (int i = 0; i < n; ++i) {
-    dust::RNG& rng = r(i % n_generators);
+    dust::RNG<double, int>& rng = r(i % n_generators);
     if (std_unif) {
       y[i] = rng.unif_rand();
     } else {
@@ -40,7 +40,7 @@ Rcpp::NumericVector test_rng_unif(int n, double min, double max, int seed,
 Rcpp::IntegerVector test_rng_binom(std::vector<int> n, std::vector<double> p,
                                    int seed, int n_generators) {
   size_t n_samples = n.size();
-  dust::pRNG r(n_generators, seed);
+  dust::pRNG<double, int> r(n_generators, seed);
 
   Rcpp::IntegerVector y(n_samples);
   for (size_t i = 0; i < n_samples; ++i) {
@@ -54,7 +54,7 @@ Rcpp::IntegerVector test_rng_binom(std::vector<int> n, std::vector<double> p,
 Rcpp::IntegerVector test_rng_pois(std::vector<double> lambda,
                                   int seed, int n_generators) {
   size_t n_samples = lambda.size();
-  dust::pRNG r(n_generators, seed);
+  dust::pRNG<double, int> r(n_generators, seed);
 
   Rcpp::IntegerVector y(n_samples);
   for (size_t i = 0; i < n_samples; ++i) {

--- a/tests/testthat/test-example.R
+++ b/tests/testthat/test-example.R
@@ -153,3 +153,26 @@ test_that("validate reorder vector is in correct range", {
   index[5] <- -1L
   expect_error(obj$reorder(index), msg, fixed = TRUE)
 })
+
+
+test_that("run in float mode", {
+  res_d <- compile_and_load(dust_file("examples/walk.cpp"), "walk", "mywalk",
+                            quiet = TRUE)
+
+  path <- tempfile(fileext = ".cpp")
+  code <- readLines(dust_file("examples/walk.cpp"))
+  pat <- "typedef double real_t"
+  stopifnot(sum(grepl(pat, code)) == 1)
+  writeLines(sub(pat, "typedef float real_t", code), path)
+  res_f <- compile_and_load(path, "walk", "mywalkf", quiet = TRUE)
+
+  n <- 1000
+  obj_d <- res_d$new(list(sd = 10), 0, n)
+  obj_f <- res_f$new(list(sd = 10), 0, n)
+
+  y_d <- obj_d$run(10)
+  y_f <- obj_f$run(10)
+
+  expect_equal(y_d, y_f, tolerance = 1e-5)
+  expect_false(identical(y_d, y_f))
+})


### PR DESCRIPTION
This PR removes explicit use of `double` and `int` from (almost) all functions in dust. This will break odin.dust but the fix there is relative small and can be done as https://github.com/mrc-ide/odin.dust/issues/4 (see https://github.com/mrc-ide/odin.dust/pull/5 for progress). It also breaks mcstate (see https://github.com/mrc-ide/mcstate/pull/18 for fix).

Things I'd like feedback on:

* The binomial.hpp function includes lots of use of `double` that I am not totally sure about templating away - I've not updated that blindly as I am not familiar with the algorithm but it looks like that should be ok?
* Both `double` and `int` are templated - if we only need a `double`/`float` distinction we could make this somewhat simpler
* There are no tests that the `float` interface actually works mostly because it's not obvious to me what a good test would look like here?
* It would be possible to make the `T::int_t` and `T::real_t` typedefs in the model class optional and default to `int` and `double` respectively. However, that will involve some fairly ugly template magic I think, plus I am leading to doing this explicitly everywhere to make it less easy to get wrong...

Fixes #27