### PR TITLE
i24 progress towards getting arbitrary information out of the dust object

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dust
 Title: Iterate Multiple Realisations of Stochastic Models
-Version: 0.0.2
+Version: 0.0.3
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("John", "Lees", role = "aut"),

--- a/R/interface.R
+++ b/R/interface.R
@@ -219,14 +219,17 @@ dust_class <- function(alloc, run, reset, state, step, reorder,
       cpp_state = state,
       cpp_step = step,
       cpp_reorder = reorder,
+      data = NULL,
       ptr = NULL
     ),
 
     public = list(
       initialize = function(data, step, n_particles, n_threads = 1L,
                             n_generators = 1L, seed = 1L) {
-        private$ptr <- .Call(private$cpp_alloc, data, step, n_particles,
-                             n_threads, n_generators, seed)
+        res <- .Call(private$cpp_alloc, data, step, n_particles,
+                     n_threads, n_generators, seed)
+        private$ptr <- res[[1L]]
+        private$data <- res[[2L]]
       },
 
       run = function(step_end) {
@@ -234,7 +237,7 @@ dust_class <- function(alloc, run, reset, state, step, reorder,
       },
 
       reset = function(data, step) {
-        .Call(private$cpp_reset, private$ptr, data, step)
+        private$data <- .Call(private$cpp_reset, private$ptr, data, step)
         invisible()
       },
 
@@ -249,6 +252,10 @@ dust_class <- function(alloc, run, reset, state, step, reorder,
       reorder = function(index) {
         .Call(private$cpp_reorder, private$ptr, as.integer(index))
         invisible()
+      },
+
+      info = function() {
+        private$data
       }
     ))
 }

--- a/R/interface.R
+++ b/R/interface.R
@@ -61,6 +61,23 @@
 ##'   the returned object must be standard C/C++ (e.g., STL) types and
 ##'   *not* Rcpp types.
 ##'
+##' Your model *may* provided a template specialisation
+##'   `dust_data<model::init_t>()` returning a `Rcpp::RObject` for
+##'   returning arbitrary information back to the R session:
+##'
+##' ```
+##' template <>
+##' Rcpp::RObject dust_info<model>(const model::init_t& data) {
+##'   return Rcpp::wrap(...);
+##' }
+##' ```
+##'
+##' What you do with this is up to you. If not present then the
+##'   `info()` method on the created object will return `NULL`.
+##'   Potential use cases for this are to return information about
+##'   variable ordering, or any processing done while accepting the
+##'   data object used to create the data fed into the particles.
+##'
 ##' @title Create a dust model from a C++ input file
 ##'
 ##' @param filename The path to a single C++ file
@@ -201,6 +218,13 @@ dust_interface <- R6::R6Class(
     ##' indicating the index of the current particles that new particles should
     ##' take.
     reorder = function(index) {
+    },
+
+    ##' @description
+    ##' Returns information about the data that your model was created with.
+    ##' Only returns non-NULL if the model provides a `dust_info` template
+    ##' specialisation.
+    info = function() {
     }
   ))
 

--- a/inst/examples/sir.cpp
+++ b/inst/examples/sir.cpp
@@ -55,13 +55,29 @@ sir::init_t dust_data<sir>(Rcpp::List data) {
   double I0 = 10.0;
   double S0 = 1000.0;
   double steps_per_day = 4;
-  // Some boilerplate needed here in order to set user parameters
-  // given a default that exists, though we'll never be using it like
-  // that?
   double dt = 1 / (double) steps_per_day;
   double initial_I = I0;
   double initial_S = S0;
   double p_IR = 1 - std::exp(-(gamma));
+
+  if (data.containsElementNamed("beta")) {
+    beta = Rcpp::as<double>(data["beta"]);
+  }
+  if (data.containsElementNamed("gamma")) {
+    gamma = Rcpp::as<double>(data["gamma"]);
+  }
+
   return sir::init_t{beta, dt, gamma, I0, initial_I, initial_R, initial_S,
       p_IR, S0, steps_per_day};
+}
+
+template <>
+Rcpp::RObject dust_info<sir>(const sir::init_t& data) {
+  // Information about state order
+  Rcpp::CharacterVector vars = Rcpp::CharacterVector::create("S", "I", "R");
+  // Information about parameter values
+  Rcpp::List pars = Rcpp::List::create(Rcpp::Named("beta") = data.beta,
+                                       Rcpp::Named("gamma") = data.gamma);
+  return Rcpp::List::create(Rcpp::Named("vars") = vars,
+                            Rcpp::Named("pars") = pars);
 }

--- a/inst/examples/sir.cpp
+++ b/inst/examples/sir.cpp
@@ -65,9 +65,3 @@ sir::init_t dust_data<sir>(Rcpp::List data) {
   return sir::init_t{beta, dt, gamma, I0, initial_I, initial_R, initial_S,
       p_IR, S0, steps_per_day};
 }
-
-// template <>
-// Rcpp::RObject dust_info<sir>(const sir::init_t& data) {
-//   std::vector<std::string> nms{"S", "I", "R"};
-//   return Rcpp::wrap(nms);
-// }

--- a/inst/examples/sir.cpp
+++ b/inst/examples/sir.cpp
@@ -66,8 +66,8 @@ sir::init_t dust_data<sir>(Rcpp::List data) {
       p_IR, S0, steps_per_day};
 }
 
-template <>
-Rcpp::RObject dust_info<sir>(const sir::init_t& data) {
-  std::vector<std::string> nms{"S", "I", "R"};
-  return Rcpp::wrap(nms);
-}
+// template <>
+// Rcpp::RObject dust_info<sir>(const sir::init_t& data) {
+//   std::vector<std::string> nms{"S", "I", "R"};
+//   return Rcpp::wrap(nms);
+// }

--- a/inst/examples/sir.cpp
+++ b/inst/examples/sir.cpp
@@ -65,3 +65,9 @@ sir::init_t dust_data<sir>(Rcpp::List data) {
   return sir::init_t{beta, dt, gamma, I0, initial_I, initial_R, initial_S,
       p_IR, S0, steps_per_day};
 }
+
+template <>
+Rcpp::RObject dust_info<sir>(const sir::init_t& data) {
+  std::vector<std::string> nms{"S", "I", "R"};
+  return Rcpp::wrap(nms);
+}

--- a/inst/examples/walk.cpp
+++ b/inst/examples/walk.cpp
@@ -29,3 +29,9 @@ walk::init_t dust_data<walk>(Rcpp::List data) {
   walk::real_t sd = Rcpp::as<walk::real_t>(data["sd"]);
   return walk::init_t{sd};
 }
+
+template <>
+Rcpp::RObject dust_info<walk>(const walk::init_t& data) {
+  // std::pair<std::string, double> ret("sd", data.sd);
+  return Rcpp::wrap(data.sd);
+}

--- a/inst/examples/walk.cpp
+++ b/inst/examples/walk.cpp
@@ -32,6 +32,5 @@ walk::init_t dust_data<walk>(Rcpp::List data) {
 
 template <>
 Rcpp::RObject dust_info<walk>(const walk::init_t& data) {
-  // std::pair<std::string, double> ret("sd", data.sd);
   return Rcpp::wrap(data.sd);
 }

--- a/inst/examples/walk.cpp
+++ b/inst/examples/walk.cpp
@@ -29,8 +29,3 @@ walk::init_t dust_data<walk>(Rcpp::List data) {
   walk::real_t sd = Rcpp::as<walk::real_t>(data["sd"]);
   return walk::init_t{sd};
 }
-
-template <>
-Rcpp::RObject dust_info<walk>(const walk::init_t& data) {
-  return Rcpp::wrap(data.sd);
-}

--- a/inst/include/dust/interface.hpp
+++ b/inst/include/dust/interface.hpp
@@ -2,13 +2,17 @@
 
 template <typename T>
 typename T::init_t dust_data(Rcpp::List data);
+
+template <typename T>
+typename Rcpp::RObject dust_info(const typename T::init_t& data);
+
 inline void validate_n(size_t n_generators, size_t n_threads);
 inline void validate_size(int x, const char * name);
 
 template <typename T>
-Rcpp::XPtr<Dust<T>> dust_alloc(Rcpp::List r_data, int step,
-                               int n_particles, int n_threads,
-                               int n_generators, int seed) {
+Rcpp::List dust_alloc(Rcpp::List r_data, int step,
+                      int n_particles, int n_threads,
+                      int n_generators, int seed) {
   validate_size(step, "step");
   validate_size(n_particles, "n_particles");
   validate_size(n_threads, "n_threads");
@@ -26,7 +30,9 @@ Rcpp::XPtr<Dust<T>> dust_alloc(Rcpp::List r_data, int step,
     new Dust<T>(data, step, index_y, n_particles, n_threads, n_generators,
                 seed);
   Rcpp::XPtr<Dust<T>> ptr(d, false);
-  return ptr;
+  Rcpp::RObject info = dust_info<T>(data);
+
+  return Rcpp::List::create(ptr, info);
 }
 
 template <typename T>
@@ -46,11 +52,12 @@ Rcpp::NumericMatrix dust_run(SEXP ptr, int step_end) {
 }
 
 template <typename T>
-void dust_reset(SEXP ptr, Rcpp::List r_data, int step) {
+Rcpp::RObject dust_reset(SEXP ptr, Rcpp::List r_data, int step) {
   validate_size(step, "step");
   typename T::init_t data = dust_data<T>(r_data);
   Dust<T> *obj = Rcpp::as<Rcpp::XPtr<Dust<T>>>(ptr);
   obj->reset(data, step);
+  return dust_info<T>(data);
 }
 
 template <typename T>

--- a/inst/include/dust/interface.hpp
+++ b/inst/include/dust/interface.hpp
@@ -101,6 +101,13 @@ void dust_reorder(SEXP ptr, Rcpp::IntegerVector r_index) {
   obj->reorder(index);
 }
 
+// Trivial default implementation of a method for getting back
+// arbitrary information from the object.
+template <typename T>
+Rcpp::RObject dust_info(const typename T::init_t& data) {
+  return R_NilValue;
+}
+
 inline void validate_n(size_t n_generators, size_t n_threads) {
   if (n_generators < n_threads) {
     Rcpp::stop("n_generators must be at least n_threads");

--- a/inst/template/dust.cpp
+++ b/inst/template/dust.cpp
@@ -16,8 +16,8 @@ SEXP {{name}}_run(SEXP ptr, size_t step_end) {
 }
 
 // [[Rcpp::export(rng = false)]]
-void {{name}}_reset(SEXP ptr, Rcpp::List r_data, size_t step) {
-  dust_reset<{{type}}>(ptr, r_data, step);
+SEXP {{name}}_reset(SEXP ptr, Rcpp::List r_data, size_t step) {
+  return dust_reset<{{type}}>(ptr, r_data, step);
 }
 
 // [[Rcpp::export(rng = false)]]

--- a/man/dust.Rd
+++ b/man/dust.Rd
@@ -85,6 +85,20 @@ With the body interacting with \code{data} to create an object of type
 in serial and may use anything in the Rcpp API.  All elements of
 the returned object must be standard C/C++ (e.g., STL) types and
 \emph{not} Rcpp types.
+
+Your model \emph{may} provided a template specialisation
+\verb{dust_data<model::init_t>()} returning a \code{Rcpp::RObject} for
+returning arbitrary information back to the R session:\preformatted{template <>
+Rcpp::RObject dust_info<model>(const model::init_t& data) \{
+  return Rcpp::wrap(...);
+\}
+}
+
+What you do with this is up to you. If not present then the
+\code{info()} method on the created object will return \code{NULL}.
+Potential use cases for this are to return information about
+variable ordering, or any processing done while accepting the
+data object used to create the data fed into the particles.
 }
 
 \examples{
@@ -131,6 +145,7 @@ obj$state()
 \item \href{#method-state}{\code{dust_interface$state()}}
 \item \href{#method-step}{\code{dust_interface$step()}}
 \item \href{#method-reorder}{\code{dust_interface$reorder()}}
+\item \href{#method-info}{\code{dust_interface$info()}}
 }
 }
 \if{html}{\out{<hr>}}
@@ -254,5 +269,17 @@ take.}
 }
 \if{html}{\out{</div>}}
 }
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-info"></a>}}
+\if{latex}{\out{\hypertarget{method-info}{}}}
+\subsection{Method \code{info()}}{
+Returns information about the data that your model was created with.
+Only returns non-NULL if the model provides a \code{dust_info} template
+specialisation.
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{dust_interface$info()}\if{html}{\out{</div>}}
+}
+
 }
 }

--- a/tests/testthat/test-example.R
+++ b/tests/testthat/test-example.R
@@ -53,6 +53,8 @@ test_that("Basic sir model", {
                           quiet = TRUE)
 
   obj <- res$new(list(), 0, 100)
+  expect_null(obj$info())
+
   ans <- vector("list", 150)
   for (i in seq_along(ans)) {
     value <- obj$run(i * 4)
@@ -72,8 +74,6 @@ test_that("Basic sir model", {
   expect_false(all(state_i[-n, ] - state_i[-1, ] >= 0))
   expect_identical(value, state_s)
   expect_equal(step, seq(4, by = 4, length.out = n))
-
-  expect_equal(obj$info(), c("S", "I", "R"))
 })
 
 

--- a/tests/testthat/test-example.R
+++ b/tests/testthat/test-example.R
@@ -29,9 +29,11 @@ test_that("Reset particles and resume continues with rng", {
   sd2 <- 4
 
   obj <- res$new(list(sd = sd1), 0, 10)
+  expect_equal(obj$info(), sd1)
   y1 <- obj$run(5)
   expect_equal(obj$step(), 5)
   obj$reset(list(sd = sd2), 0)
+  expect_equal(obj$info(), sd2)
   expect_equal(obj$step(), 0)
   y2 <- obj$run(5)
   expect_equal(obj$step(), 5)
@@ -70,6 +72,8 @@ test_that("Basic sir model", {
   expect_false(all(state_i[-n, ] - state_i[-1, ] >= 0))
   expect_identical(value, state_s)
   expect_equal(step, seq(4, by = 4, length.out = n))
+
+  expect_equal(obj$info(), c("S", "I", "R"))
 })
 
 

--- a/tests/testthat/test-example.R
+++ b/tests/testthat/test-example.R
@@ -4,6 +4,8 @@ test_that("create walk, stepping for one step", {
   res <- compile_and_load(dust_file("examples/walk.cpp"), "walk", "mywalk",
                           quiet = TRUE)
   obj <- res$new(list(sd = 1), 0, 10)
+  expect_null(obj$info())
+
   y <- obj$run(1)
   cmp <- test_rng_norm(10, 1, 1)
   expect_identical(drop(y), cmp)
@@ -29,11 +31,10 @@ test_that("Reset particles and resume continues with rng", {
   sd2 <- 4
 
   obj <- res$new(list(sd = sd1), 0, 10)
-  expect_equal(obj$info(), sd1)
+
   y1 <- obj$run(5)
   expect_equal(obj$step(), 5)
   obj$reset(list(sd = sd2), 0)
-  expect_equal(obj$info(), sd2)
   expect_equal(obj$step(), 0)
   y2 <- obj$run(5)
   expect_equal(obj$step(), 5)
@@ -53,7 +54,6 @@ test_that("Basic sir model", {
                           quiet = TRUE)
 
   obj <- res$new(list(), 0, 100)
-  expect_null(obj$info())
 
   ans <- vector("list", 150)
   for (i in seq_along(ans)) {
@@ -179,4 +179,18 @@ test_that("run in float mode", {
 
   expect_equal(y_d, y_f, tolerance = 1e-5)
   expect_false(identical(y_d, y_f))
+})
+
+
+test_that("reset changes info", {
+  res <- compile_and_load(dust_file("examples/sir.cpp"), "sir", "mysir",
+                          quiet = TRUE)
+  obj <- res$new(list(), 0, 100)
+  expect_equal(obj$info(),
+               list(vars = c("S", "I", "R"),
+                    pars = list(beta = 0.2, gamma = 0.1)))
+  obj$reset(list(beta = 0.1), 0)
+  expect_equal(obj$info(),
+               list(vars = c("S", "I", "R"),
+                    pars = list(beta = 0.1, gamma = 0.1)))
 })


### PR DESCRIPTION
Smaller in scope than what is possible in odin, here we allow some information to be computed against the data on initialisation and reset.  This will be sufficient for odin.dust to feed back information about the way that the variables are ordered, and cope with them being resized due to parameter changes.

Must be merged after #28 and rebased/merged to get a clean diff once that's merged.

Requires work on odin.dust (https://github.com/mrc-ide/odin.dust/pull/8)

Fixes #24 (at least in the narrowest intent of that issue)