### PR TITLE
i8: allow setting index and state

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dust
 Title: Iterate Multiple Realisations of Stochastic Models
-Version: 0.0.7
+Version: 0.1.0
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("John", "Lees", role = "aut"),

--- a/R/compile.R
+++ b/R/compile.R
@@ -25,11 +25,12 @@ compile_and_load <- function(filename, type, name, quiet = FALSE,
     dyn.load(dll)
   }
 
-  v <- c("alloc", "run", "reset", "state", "step", "reorder")
+  v <- c("alloc", "run", "set_index_y", "reset", "state", "step", "reorder")
   sym <- getNativeSymbolInfo(sprintf("_%s_dust_%s_%s", base, name, v), base)
   names(sym) <- v
 
-  dust_class(sym$alloc, sym$run, sym$reset, sym$state, sym$step, sym$reorder)
+  dust_class(sym$alloc, sym$run, sym$set_index_y, sym$reset, sym$state,
+             sym$step, sym$reorder)
 }
 
 

--- a/R/compile.R
+++ b/R/compile.R
@@ -25,12 +25,12 @@ compile_and_load <- function(filename, type, name, quiet = FALSE,
     dyn.load(dll)
   }
 
-  v <- c("alloc", "run", "set_index_y", "set_state", "reset", "state",
+  v <- c("alloc", "run", "set_index", "set_state", "reset", "state",
          "step", "reorder")
   sym <- getNativeSymbolInfo(sprintf("_%s_dust_%s_%s", base, name, v), base)
   names(sym) <- v
 
-  dust_class(sym$alloc, sym$run, sym$set_index_y, sym$set_state, sym$reset,
+  dust_class(sym$alloc, sym$run, sym$set_index, sym$set_state, sym$reset,
              sym$state, sym$step, sym$reorder)
 }
 

--- a/R/compile.R
+++ b/R/compile.R
@@ -25,12 +25,13 @@ compile_and_load <- function(filename, type, name, quiet = FALSE,
     dyn.load(dll)
   }
 
-  v <- c("alloc", "run", "set_index_y", "reset", "state", "step", "reorder")
+  v <- c("alloc", "run", "set_index_y", "set_state", "reset", "state",
+         "step", "reorder")
   sym <- getNativeSymbolInfo(sprintf("_%s_dust_%s_%s", base, name, v), base)
   names(sym) <- v
 
-  dust_class(sym$alloc, sym$run, sym$set_index_y, sym$reset, sym$state,
-             sym$step, sym$reorder)
+  dust_class(sym$alloc, sym$run, sym$set_index_y, sym$set_state, sym$reset,
+             sym$state, sym$step, sym$reorder)
 }
 
 

--- a/R/interface.R
+++ b/R/interface.R
@@ -205,8 +205,6 @@ dust_interface <- R6::R6Class(
     ##' elements between 1 and the length of the state (this will be
     ##' validated, and an error thrown if an invalid index is given).
     set_index_y = function(index_y) {
-      .Call(private$cpp_set_index_y, private$ptr, index_y)
-      invisible()
     },
 
     ##' @description
@@ -217,8 +215,6 @@ dust_interface <- R6::R6Class(
     ##' @param state The state vector - must be a numeric vector with the
     ##' same length as the model's current state.
     set_state = function(state) {
-      .Call(private$cpp_set_state, private$ptr, state)
-      invisible()
     },
 
     ##' @description

--- a/R/interface.R
+++ b/R/interface.R
@@ -195,6 +195,33 @@ dust_interface <- R6::R6Class(
     },
 
     ##' @description
+    ##' Set the "index" vector that is used to return a subset of data
+    ##' after using `run()`. If this is not used then `run()` returns
+    ##' an empty (zero-row) matrix. This method must be called after any
+    ##' call to `reset()` as `reset()` may change the size of the state
+    ##' and that will invalidate the index.
+    ##'
+    ##' @param index_y The index vector - must be an integer vector with
+    ##' elements between 1 and the length of the state (this will be
+    ##' validated, and an error thrown if an invalid index is given).
+    set_index_y = function(index_y) {
+      .Call(private$cpp_set_index_y, private$ptr, index_y)
+      invisible()
+    },
+
+    ##' @description
+    ##' Set the "state" vector for all particles, overriding whatever your
+    ##' models `initial()` method provides. Currently all particles are set
+    ##' to the same state.
+    ##'
+    ##' @param state The state vector - must be a numeric vector with the
+    ##' same length as the model's current state.
+    set_state = function(state) {
+      .Call(private$cpp_set_state, private$ptr, state)
+      invisible()
+    },
+
+    ##' @description
     ##' Reset the model while preserving the random number stream state
     ##'
     ##' @param data New data for the model (see constructor)

--- a/R/interface.R
+++ b/R/interface.R
@@ -360,6 +360,8 @@ dust_workdir <- function(path) {
 ## above.
 private <- list(cpp_alloc = structure(list(), class = "NativeSymbolInfo"),
                 cpp_run = structure(list(), class = "NativeSymbolInfo"),
+                cpp_set_index = structure(list(), class = "NativeSymbolInfo"),
+                cpp_set_state = structure(list(), class = "NativeSymbolInfo"),
                 cpp_reset = structure(list(), class = "NativeSymbolInfo"),
                 cpp_state = structure(list(), class = "NativeSymbolInfo"),
                 cpp_step = structure(list(), class = "NativeSymbolInfo"),

--- a/R/interface.R
+++ b/R/interface.R
@@ -201,10 +201,10 @@ dust_interface <- R6::R6Class(
     ##' call to `reset()` as `reset()` may change the size of the state
     ##' and that will invalidate the index.
     ##'
-    ##' @param index_y The index vector - must be an integer vector with
+    ##' @param index The index vector - must be an integer vector with
     ##' elements between 1 and the length of the state (this will be
     ##' validated, and an error thrown if an invalid index is given).
-    set_index_y = function(index_y) {
+    set_index = function(index) {
     },
 
     ##' @description
@@ -253,7 +253,7 @@ dust_interface <- R6::R6Class(
   ))
 
 
-dust_class <- function(alloc, run, set_index_y, set_state, reset, state,
+dust_class <- function(alloc, run, set_index, set_state, reset, state,
                        step, reorder, classname = "dust") {
   R6::R6Class(
     classname,
@@ -262,7 +262,7 @@ dust_class <- function(alloc, run, set_index_y, set_state, reset, state,
     private = list(
       cpp_alloc = alloc,
       cpp_run = run,
-      cpp_set_index_y = set_index_y,
+      cpp_set_index = set_index,
       cpp_set_state = set_state,
       cpp_reset = reset,
       cpp_state = state,
@@ -292,8 +292,8 @@ dust_class <- function(alloc, run, set_index_y, set_state, reset, state,
         invisible()
       },
 
-      set_index_y = function(index_y) {
-        .Call(private$cpp_set_index_y, private$ptr, index_y)
+      set_index = function(index) {
+        .Call(private$cpp_set_index, private$ptr, index)
         invisible()
       },
 

--- a/R/interface.R
+++ b/R/interface.R
@@ -285,8 +285,6 @@ dust_class <- function(alloc, run, set_index, set_state, reset, state,
         .Call(private$cpp_run, private$ptr, step_end)
       },
 
-      ## TODO: this probably needs changing as we can't set state and
-      ## index until data has been set.
       reset = function(data, step) {
         private$data <- .Call(private$cpp_reset, private$ptr, data, step)
         invisible()

--- a/R/interface.R
+++ b/R/interface.R
@@ -197,7 +197,8 @@ dust_interface <- R6::R6Class(
     ##' @description
     ##' Set the "index" vector that is used to return a subset of data
     ##' after using `run()`. If this is not used then `run()` returns
-    ##' an empty (zero-row) matrix. This method must be called after any
+    ##' all elements in your state vector, which may be excessive and slower
+    ##' than necessary. This method must be called after any
     ##' call to `reset()` as `reset()` may change the size of the state
     ##' and that will invalidate the index.
     ##'

--- a/R/interface.R
+++ b/R/interface.R
@@ -230,8 +230,8 @@ dust_interface <- R6::R6Class(
   ))
 
 
-dust_class <- function(alloc, run, set_index_y, reset, state, step, reorder,
-                       classname = "dust") {
+dust_class <- function(alloc, run, set_index_y, set_state, reset, state,
+                       step, reorder, classname = "dust") {
   R6::R6Class(
     classname,
     cloneable = FALSE,
@@ -240,6 +240,7 @@ dust_class <- function(alloc, run, set_index_y, reset, state, step, reorder,
       cpp_alloc = alloc,
       cpp_run = run,
       cpp_set_index_y = set_index_y,
+      cpp_set_state = set_state,
       cpp_reset = reset,
       cpp_state = state,
       cpp_step = step,
@@ -270,6 +271,11 @@ dust_class <- function(alloc, run, set_index_y, reset, state, step, reorder,
 
       set_index_y = function(index_y) {
         .Call(private$cpp_set_index_y, private$ptr, index_y)
+        invisible()
+      },
+
+      set_state = function(state) {
+        .Call(private$cpp_set_state, private$ptr, state)
         invisible()
       },
 

--- a/R/interface.R
+++ b/R/interface.R
@@ -230,8 +230,7 @@ dust_interface <- R6::R6Class(
   ))
 
 
-
-dust_class <- function(alloc, run, reset, state, step, reorder,
+dust_class <- function(alloc, run, set_index_y, reset, state, step, reorder,
                        classname = "dust") {
   R6::R6Class(
     classname,
@@ -240,6 +239,7 @@ dust_class <- function(alloc, run, reset, state, step, reorder,
     private = list(
       cpp_alloc = alloc,
       cpp_run = run,
+      cpp_set_index_y = set_index_y,
       cpp_reset = reset,
       cpp_state = state,
       cpp_step = step,
@@ -261,8 +261,15 @@ dust_class <- function(alloc, run, reset, state, step, reorder,
         .Call(private$cpp_run, private$ptr, step_end)
       },
 
+      ## TODO: this probably needs changing as we can't set state and
+      ## index until data has been set.
       reset = function(data, step) {
         private$data <- .Call(private$cpp_reset, private$ptr, data, step)
+        invisible()
+      },
+
+      set_index_y = function(index_y) {
+        .Call(private$cpp_set_index_y, private$ptr, index_y)
         invisible()
       },
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # dust <img src='man/figures/logo.png' align="right" height="139" />
 
 <!-- badges: start -->
-[![Project Status: Concept – Minimal or no implementation has been done yet, or the repository is only intended to be a limited example, demo, or proof-of-concept.](https://www.repostatus.org/badges/latest/concept.svg)](https://www.repostatus.org/#concept)
+[![Project Status: WIP – Initial development is in progress, but there has not yet been a stable, usable release suitable for the public.](https://www.repostatus.org/badges/latest/wip.svg)](https://www.repostatus.org/#wip)
 [![Build Status](https://travis-ci.com/mrc-ide/dust.svg?branch=master)](https://travis-ci.com/mrc-ide/dust)
 [![AppVeyor build status](https://ci.appveyor.com/api/projects/status/github/mrc-ide/dust?branch=master&svg=true)](https://ci.appveyor.com/project/mrc-ide/dust)
 [![CodeFactor](https://www.codefactor.io/repository/github/mrc-ide/dust/badge)](https://www.codefactor.io/repository/github/mrc-ide/dust)

--- a/inst/examples/variable.cpp
+++ b/inst/examples/variable.cpp
@@ -1,0 +1,49 @@
+class variable {
+public:
+  typedef int int_t;
+  typedef double real_t;
+  struct init_t {
+    size_t len;
+    double mean;
+    double sd;
+  };
+
+  variable(const init_t& data) : data_(data) {
+  }
+
+  size_t size() const {
+    return data_.len;
+  }
+
+  std::vector<double> initial(size_t step) {
+    std::vector<double> ret;
+    for (size_t i = 0; i < data_.len; ++i) {
+      ret.push_back(i + 1);
+    }
+    return ret;
+  }
+
+  void update(size_t step, const std::vector<double> state,
+              dust::RNG<double, int>& rng, std::vector<double>& state_next) {
+    for (size_t i = 0; i < data_.len; ++i) {
+      state_next[i] = rng.rnorm(state[i] + data_.mean, data_.sd);
+    }
+  }
+
+private:
+  init_t data_;
+};
+
+#include <Rcpp.h>
+template <>
+variable::init_t dust_data<variable>(Rcpp::List data) {
+  const size_t len = Rcpp::as<int>(data["len"]);
+  double mean = 0, sd = 1;
+  if (data.containsElementNamed("mean")) {
+    mean = Rcpp::as<double>(data["mean"]);
+  }
+  if (data.containsElementNamed("sd")) {
+    sd = Rcpp::as<double>(data["sd"]);
+  }
+  return variable::init_t{len, mean, sd};
+}

--- a/inst/include/dust/dust.hpp
+++ b/inst/include/dust/dust.hpp
@@ -80,10 +80,8 @@ public:
   typedef typename dust::RNG<real_t, int_t> rng_t;
 
   Dust(const init_t data, const size_t step,
-       const std::vector<size_t> index_y,
        const size_t n_particles, const size_t n_threads,
        const size_t n_generators, const size_t seed) :
-    _index_y(index_y),
     _n_threads(n_threads),
     _rng(n_generators, seed) {
     for (size_t i = 0; i < n_particles; ++i) {

--- a/inst/include/dust/dust.hpp
+++ b/inst/include/dust/dust.hpp
@@ -88,18 +88,12 @@ public:
        const size_t n_generators, const size_t seed) :
     _n_threads(n_threads),
     _rng(n_generators, seed) {
-    for (size_t i = 0; i < n_particles; ++i) {
-      _particles.push_back(Particle<T>(data, step));
-    }
+    initialise(data, step, n_particles);
   }
 
   void reset(const init_t data, const size_t step) {
     const size_t n_particles = _particles.size();
-    _index.clear();
-    _particles.clear();
-    for (size_t i = 0; i < n_particles; ++i) {
-      _particles.push_back(Particle<T>(data, step));
-    }
+    initialise(data, step, n_particles);
   }
 
   // It's the callee's responsibility to ensure that index is in
@@ -234,6 +228,22 @@ private:
   // loop leftovers either.
   rng_t& pick_generator(const size_t i) {
     return _rng(i % _rng.size());
+  }
+
+  void initialise(const init_t data, const size_t step,
+                  const size_t n_particles) {
+    _particles.clear();
+    _particles.reserve(n_particles);
+    for (size_t i = 0; i < n_particles; ++i) {
+      _particles.push_back(Particle<T>(data, step));
+    }
+
+    const size_t n = n_state_full();
+    _index.clear();
+    _index.reserve(n);
+    for (size_t i = 0; i < n; ++i) {
+      _index.push_back(i);
+    }
   }
 };
 

--- a/inst/include/dust/dust.hpp
+++ b/inst/include/dust/dust.hpp
@@ -63,6 +63,10 @@ public:
     _y_swap = other._y;
   }
 
+  void update(const std::vector<real_t>& state) {
+    std::copy(state.begin(), state.end(), _y.begin());
+  }
+
 private:
   T _model;
   size_t _step;
@@ -90,20 +94,25 @@ public:
   }
 
   void reset(const init_t data, const size_t step) {
-    size_t n_particles = _particles.size();
+    const size_t n_particles = _particles.size();
     _particles.clear();
     for (size_t i = 0; i < n_particles; ++i) {
       _particles.push_back(Particle<T>(data, step));
     }
   }
 
-  // It's the call-ee's responsibility to ensure that index_y is in
+  // It's the callee's responsibility to ensure that index_y is in
   // range [0, n-1]
-  //
-  // This method will likely change to also accept the starting state,
-  // I think (see #6), and when it does it will change name.
-  void set_index_y(std::vector<size_t> index_y) {
+  void set_index_y(const std::vector<size_t>& index_y) {
     _index_y = index_y;
+  }
+
+  // It's the callee's responsibility to ensure this is the correct length
+  void set_state(const std::vector<real_t>& state) {
+    const size_t n_particles = _particles.size();
+    for (size_t i = 0; i < n_particles; ++i) {
+      _particles[i].update(state);
+    }
   }
 
   void run(const size_t step_end) {

--- a/inst/include/dust/dust.hpp
+++ b/inst/include/dust/dust.hpp
@@ -95,6 +95,7 @@ public:
 
   void reset(const init_t data, const size_t step) {
     const size_t n_particles = _particles.size();
+    _index_y.clear();
     _particles.clear();
     for (size_t i = 0; i < n_particles; ++i) {
       _particles.push_back(Particle<T>(data, step));

--- a/inst/include/dust/dust.hpp
+++ b/inst/include/dust/dust.hpp
@@ -99,6 +99,15 @@ public:
     }
   }
 
+  // It's the call-ee's responsibility to ensure that index_y is in
+  // range [0, n-1]
+  //
+  // This method will likely change to also accept the starting state,
+  // I think (see #6), and when it does it will change name.
+  void set_index_y(std::vector<size_t> index_y) {
+    _index_y = index_y;
+  }
+
   void run(const size_t step_end) {
     #pragma omp parallel num_threads(_n_threads)
     {
@@ -172,18 +181,21 @@ public:
   size_t n_particles() const {
     return _particles.size();
   }
+
   size_t n_state() const {
     return _index_y.size();
   }
+
   size_t n_state_full() const {
     return _particles.front().size();
   }
+
   size_t step() const {
     return _particles.front().step();
   }
 
 private:
-  const std::vector<size_t> _index_y;
+  std::vector<size_t> _index_y;
   const size_t _n_threads;
   dust::pRNG<real_t, int_t> _rng;
   std::vector<Particle<T>> _particles;

--- a/inst/include/dust/dust.hpp
+++ b/inst/include/dust/dust.hpp
@@ -34,10 +34,10 @@ public:
     }
   }
 
-  void state(const std::vector<size_t>& index_y,
+  void state(const std::vector<size_t>& index,
              typename std::vector<real_t>::iterator end_state) const {
-    for (size_t i = 0; i < index_y.size(); ++i) {
-      *(end_state + i) = _y[index_y[i]];
+    for (size_t i = 0; i < index.size(); ++i) {
+      *(end_state + i) = _y[index[i]];
     }
   }
 
@@ -95,17 +95,17 @@ public:
 
   void reset(const init_t data, const size_t step) {
     const size_t n_particles = _particles.size();
-    _index_y.clear();
+    _index.clear();
     _particles.clear();
     for (size_t i = 0; i < n_particles; ++i) {
       _particles.push_back(Particle<T>(data, step));
     }
   }
 
-  // It's the callee's responsibility to ensure that index_y is in
+  // It's the callee's responsibility to ensure that index is in
   // range [0, n-1]
-  void set_index_y(const std::vector<size_t>& index_y) {
-    _index_y = index_y;
+  void set_index(const std::vector<size_t>& index) {
+    _index = index;
   }
 
   // It's the callee's responsibility to ensure this is the correct length
@@ -143,15 +143,15 @@ public:
   void state(std::vector<real_t>& end_state) const {
     #pragma omp parallel for schedule(static) num_threads(_n_threads)
     for (size_t i = 0; i < _particles.size(); ++i) {
-      _particles[i].state(_index_y, end_state.begin() + i * _index_y.size());
+      _particles[i].state(_index, end_state.begin() + i * _index.size());
     }
   }
 
-  void state(std::vector<size_t> index_y,
+  void state(std::vector<size_t> index,
              std::vector<real_t>& end_state) const {
     #pragma omp parallel for schedule(static) num_threads(_n_threads)
     for (size_t i = 0; i < _particles.size(); ++i) {
-      _particles[i].state(index_y, end_state.begin() + i * index_y.size());
+      _particles[i].state(index, end_state.begin() + i * index.size());
     }
   }
 
@@ -191,7 +191,7 @@ public:
   }
 
   size_t n_state() const {
-    return _index_y.size();
+    return _index.size();
   }
 
   size_t n_state_full() const {
@@ -203,7 +203,7 @@ public:
   }
 
 private:
-  std::vector<size_t> _index_y;
+  std::vector<size_t> _index;
   const size_t _n_threads;
   dust::pRNG<real_t, int_t> _rng;
   std::vector<Particle<T>> _particles;

--- a/inst/include/dust/interface.hpp
+++ b/inst/include/dust/interface.hpp
@@ -41,6 +41,18 @@ void dust_set_index_y(SEXP ptr, Rcpp::IntegerVector r_index_y) {
 }
 
 template <typename T>
+void dust_set_state(SEXP ptr, Rcpp::NumericVector r_state) {
+  Dust<T> *obj = Rcpp::as<Rcpp::XPtr<Dust<T>>>(ptr);
+  const size_t n_state = obj->n_state_full();
+  if (static_cast<size_t>(r_state.size()) != n_state) {
+    Rcpp::stop("Expected a vector with %d elements for 'state'", n_state);
+  }
+  // TODO: make flexible with types
+  const std::vector<double> state = Rcpp::as<std::vector<double>>(r_state);
+  obj->set_state(state);
+}
+
+template <typename T>
 Rcpp::NumericMatrix dust_run(SEXP ptr, int step_end) {
   validate_size(step_end, "step_end");
   Dust<T> *obj = Rcpp::as<Rcpp::XPtr<Dust<T>>>(ptr);

--- a/inst/include/dust/interface.hpp
+++ b/inst/include/dust/interface.hpp
@@ -33,11 +33,11 @@ Rcpp::List dust_alloc(Rcpp::List r_data, int step,
 }
 
 template <typename T>
-void dust_set_index_y(SEXP ptr, Rcpp::IntegerVector r_index_y) {
+void dust_set_index(SEXP ptr, Rcpp::IntegerVector r_index) {
   Dust<T> *obj = Rcpp::as<Rcpp::XPtr<Dust<T>>>(ptr);
   const size_t index_max = obj->n_state_full();
-  const std::vector<size_t> index = r_index_to_index(r_index_y, index_max);
-  obj->set_index_y(index);
+  const std::vector<size_t> index = r_index_to_index(r_index, index_max);
+  obj->set_index(index);
 }
 
 template <typename T>

--- a/inst/include/dust/interface.hpp
+++ b/inst/include/dust/interface.hpp
@@ -47,8 +47,8 @@ void dust_set_state(SEXP ptr, Rcpp::NumericVector r_state) {
   if (static_cast<size_t>(r_state.size()) != n_state) {
     Rcpp::stop("Expected a vector with %d elements for 'state'", n_state);
   }
-  // TODO: make flexible with types
-  const std::vector<double> state = Rcpp::as<std::vector<double>>(r_state);
+  const std::vector<typename T::real_t> state =
+    Rcpp::as<std::vector<typename T::real_t>>(r_state);
   obj->set_state(state);
 }
 

--- a/inst/include/dust/interface.hpp
+++ b/inst/include/dust/interface.hpp
@@ -23,14 +23,9 @@ Rcpp::List dust_alloc(Rcpp::List r_data, int step,
   validate_n(n_generators, n_threads);
 
   typename T::init_t data = dust_data<T>(r_data);
-  std::vector<size_t> index_y = {0};
-
-  // TODO: can't customise initial state
-  // TODO: can't customise index y
 
   Dust<T> *d =
-    new Dust<T>(data, step, index_y, n_particles, n_threads, n_generators,
-                seed);
+    new Dust<T>(data, step, n_particles, n_threads, n_generators, seed);
   Rcpp::XPtr<Dust<T>> ptr(d, false);
   Rcpp::RObject info = dust_info<T>(data);
 

--- a/inst/include/dust/interface.hpp
+++ b/inst/include/dust/interface.hpp
@@ -38,6 +38,14 @@ Rcpp::List dust_alloc(Rcpp::List r_data, int step,
 }
 
 template <typename T>
+void dust_set_index_y(SEXP ptr, Rcpp::IntegerVector r_index_y) {
+  Dust<T> *obj = Rcpp::as<Rcpp::XPtr<Dust<T>>>(ptr);
+  const size_t index_max = obj->n_state_full();
+  const std::vector<size_t> index = r_index_to_index(r_index_y, index_max);
+  obj->set_index_y(index);
+}
+
+template <typename T>
 Rcpp::NumericMatrix dust_run(SEXP ptr, int step_end) {
   validate_size(step_end, "step_end");
   Dust<T> *obj = Rcpp::as<Rcpp::XPtr<Dust<T>>>(ptr);

--- a/inst/template/dust.R.template
+++ b/inst/template/dust.R.template
@@ -22,6 +22,14 @@
       dust_{{name}}_run(private$ptr, step_end)
     },
 
+    set_index_y = function(index_y) {
+      dust_{{name}}_set_index_y(private$ptr, index_y)
+    },
+
+    set_state = function(state) {
+      dust_{{name}}_set_state(private$ptr, state)
+    },
+
     reset = function(data, step) {
       private$data <- dust_{{name}}_reset(private$ptr, data, step)
       invisible()

--- a/inst/template/dust.R.template
+++ b/inst/template/dust.R.template
@@ -22,8 +22,8 @@
       dust_{{name}}_run(private$ptr, step_end)
     },
 
-    set_index_y = function(index_y) {
-      dust_{{name}}_set_index_y(private$ptr, index_y)
+    set_index = function(index) {
+      dust_{{name}}_set_index(private$ptr, index)
     },
 
     set_state = function(state) {

--- a/inst/template/dust.cpp
+++ b/inst/template/dust.cpp
@@ -22,6 +22,12 @@ SEXP dust_{{name}}_set_index_y(SEXP ptr, Rcpp::IntegerVector r_index_y) {
 }
 
 // [[Rcpp::export(rng = false)]]
+SEXP dust_{{name}}_set_state(SEXP ptr, Rcpp::NumericVector r_state) {
+  dust_set_state<{{type}}>(ptr, r_state);
+  return R_NilValue;
+}
+
+// [[Rcpp::export(rng = false)]]
 SEXP dust_{{name}}_reset(SEXP ptr, Rcpp::List r_data, size_t step) {
   return dust_reset<{{type}}>(ptr, r_data, step);
 }

--- a/inst/template/dust.cpp
+++ b/inst/template/dust.cpp
@@ -16,8 +16,8 @@ SEXP dust_{{name}}_run(SEXP ptr, size_t step_end) {
 }
 
 // [[Rcpp::export(rng = false)]]
-SEXP dust_{{name}}_set_index_y(SEXP ptr, Rcpp::IntegerVector r_index_y) {
-  dust_set_index_y<{{type}}>(ptr, r_index_y);
+SEXP dust_{{name}}_set_index(SEXP ptr, Rcpp::IntegerVector r_index) {
+  dust_set_index<{{type}}>(ptr, r_index);
   return R_NilValue;
 }
 

--- a/inst/template/dust.cpp
+++ b/inst/template/dust.cpp
@@ -16,6 +16,12 @@ SEXP dust_{{name}}_run(SEXP ptr, size_t step_end) {
 }
 
 // [[Rcpp::export(rng = false)]]
+SEXP dust_{{name}}_set_index_y(SEXP ptr, Rcpp::IntegerVector r_index_y) {
+  dust_set_index_y<{{type}}>(ptr, r_index_y);
+  return R_NilValue;
+}
+
+// [[Rcpp::export(rng = false)]]
 SEXP dust_{{name}}_reset(SEXP ptr, Rcpp::List r_data, size_t step) {
   return dust_reset<{{type}}>(ptr, r_data, step);
 }

--- a/man/dust.Rd
+++ b/man/dust.Rd
@@ -141,7 +141,7 @@ obj$state()
 \itemize{
 \item \href{#method-new}{\code{dust_interface$new()}}
 \item \href{#method-run}{\code{dust_interface$run()}}
-\item \href{#method-set_index_y}{\code{dust_interface$set_index_y()}}
+\item \href{#method-set_index}{\code{dust_interface$set_index()}}
 \item \href{#method-set_state}{\code{dust_interface$set_state()}}
 \item \href{#method-reset}{\code{dust_interface$reset()}}
 \item \href{#method-state}{\code{dust_interface$state()}}
@@ -215,22 +215,22 @@ step(),silently nothing will happen)}
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-set_index_y"></a>}}
-\if{latex}{\out{\hypertarget{method-set_index_y}{}}}
-\subsection{Method \code{set_index_y()}}{
+\if{html}{\out{<a id="method-set_index"></a>}}
+\if{latex}{\out{\hypertarget{method-set_index}{}}}
+\subsection{Method \code{set_index()}}{
 Set the "index" vector that is used to return a subset of data
 after using \code{run()}. If this is not used then \code{run()} returns
 an empty (zero-row) matrix. This method must be called after any
 call to \code{reset()} as \code{reset()} may change the size of the state
 and that will invalidate the index.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{dust_interface$set_index_y(index_y)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{dust_interface$set_index(index)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
-\item{\code{index_y}}{The index vector - must be an integer vector with
+\item{\code{index}}{The index vector - must be an integer vector with
 elements between 1 and the length of the state (this will be
 validated, and an error thrown if an invalid index is given).}
 }

--- a/man/dust.Rd
+++ b/man/dust.Rd
@@ -220,7 +220,8 @@ step(),silently nothing will happen)}
 \subsection{Method \code{set_index()}}{
 Set the "index" vector that is used to return a subset of data
 after using \code{run()}. If this is not used then \code{run()} returns
-an empty (zero-row) matrix. This method must be called after any
+all elements in your state vector, which may be excessive and slower
+than necessary. This method must be called after any
 call to \code{reset()} as \code{reset()} may change the size of the state
 and that will invalidate the index.
 \subsection{Usage}{

--- a/man/dust.Rd
+++ b/man/dust.Rd
@@ -141,6 +141,8 @@ obj$state()
 \itemize{
 \item \href{#method-new}{\code{dust_interface$new()}}
 \item \href{#method-run}{\code{dust_interface$run()}}
+\item \href{#method-set_index_y}{\code{dust_interface$set_index_y()}}
+\item \href{#method-set_state}{\code{dust_interface$set_state()}}
 \item \href{#method-reset}{\code{dust_interface$reset()}}
 \item \href{#method-state}{\code{dust_interface$state()}}
 \item \href{#method-step}{\code{dust_interface$step()}}
@@ -208,6 +210,49 @@ at that point.
 \describe{
 \item{\code{step_end}}{Step to run to (if less than or equal to the current
 step(),silently nothing will happen)}
+}
+\if{html}{\out{</div>}}
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-set_index_y"></a>}}
+\if{latex}{\out{\hypertarget{method-set_index_y}{}}}
+\subsection{Method \code{set_index_y()}}{
+Set the "index" vector that is used to return a subset of data
+after using \code{run()}. If this is not used then \code{run()} returns
+an empty (zero-row) matrix. This method must be called after any
+call to \code{reset()} as \code{reset()} may change the size of the state
+and that will invalidate the index.
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{dust_interface$set_index_y(index_y)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{index_y}}{The index vector - must be an integer vector with
+elements between 1 and the length of the state (this will be
+validated, and an error thrown if an invalid index is given).}
+}
+\if{html}{\out{</div>}}
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-set_state"></a>}}
+\if{latex}{\out{\hypertarget{method-set_state}{}}}
+\subsection{Method \code{set_state()}}{
+Set the "state" vector for all particles, overriding whatever your
+models \code{initial()} method provides. Currently all particles are set
+to the same state.
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{dust_interface$set_state(state)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{state}}{The state vector - must be a numeric vector with the
+same length as the model's current state.}
 }
 \if{html}{\out{</div>}}
 }

--- a/tests/testthat/test-example.R
+++ b/tests/testthat/test-example.R
@@ -89,6 +89,21 @@ test_that("Basic sir model", {
 })
 
 
+test_that("work with index_y", {
+  res <- dust(dust_file("examples/variable.cpp"), quiet = TRUE)
+  mod <- res$new(list(len = 10), 0, 1)
+  expect_equal(mod$state(), matrix(1:10))
+  expect_equal(mod$run(0), matrix(1))
+
+  mod$set_index_y(2:4)
+  expect_equal(mod$run(0), matrix(2:4))
+
+  y <- mod$run(1)
+  expect_equal(y, mod$state(2:4))
+  expect_equal(y, mod$state()[2:4, , drop = FALSE])
+})
+
+
 test_that("reorder", {
   res <- compile_and_load(dust_file("examples/walk.cpp"), "walk", "mywalk",
                           quiet = TRUE)

--- a/tests/testthat/test-example.R
+++ b/tests/testthat/test-example.R
@@ -4,7 +4,6 @@ test_that("create walk, stepping for one step", {
   res <- compile_and_load(dust_file("examples/walk.cpp"), "walk", "mywalk",
                           quiet = TRUE)
   obj <- res$new(list(sd = 1), 0, 10)
-  obj$set_index(1)
   expect_null(obj$info())
 
   y <- obj$run(1)
@@ -17,7 +16,6 @@ test_that("walk agrees with random number stream", {
   res <- compile_and_load(dust_file("examples/walk.cpp"), "walk", "mywalk",
                           quiet = TRUE)
   obj <- res$new(list(sd = 1), 0, 10, seed = 1L)
-  obj$set_index(1)
   y <- obj$run(5)
 
   cmp <- dust_rng$new(1, 1)$rnorm(50, 0, 1)
@@ -33,12 +31,10 @@ test_that("Reset particles and resume continues with rng", {
   sd2 <- 4
 
   obj <- res$new(list(sd = sd1), 0, 10)
-  obj$set_index(1)
 
   y1 <- obj$run(5)
   expect_equal(obj$step(), 5)
   obj$reset(list(sd = sd2), 0)
-  obj$set_index(1)
   expect_equal(obj$step(), 0)
   y2 <- obj$run(5)
   expect_equal(obj$step(), 5)
@@ -98,7 +94,7 @@ test_that("set index", {
   res <- dust(dust_file("examples/variable.cpp"), quiet = TRUE)
   mod <- res$new(list(len = 10), 0, 1)
   expect_equal(mod$state(), matrix(1:10))
-  expect_equal(mod$run(0), matrix(numeric(), nrow = 0, ncol = 1))
+  expect_equal(mod$run(0), matrix(1:10, nrow = 10, ncol = 1))
 
   mod$set_index(2:4)
   expect_equal(mod$run(0), matrix(2:4))
@@ -106,6 +102,9 @@ test_that("set index", {
   y <- mod$run(1)
   expect_equal(y, mod$state(2:4))
   expect_equal(y, mod$state()[2:4, , drop = FALSE])
+
+  mod$set_index(integer(0))
+  expect_equal(mod$run(1), matrix(numeric(0), nrow = 0, ncol = 1))
 })
 
 
@@ -115,7 +114,7 @@ test_that("reset clears the index", {
   mod$set_index(2:4)
   expect_equal(mod$run(0), matrix(2:4))
   mod$reset(list(len = 10), 0)
-  expect_equal(mod$run(0), matrix(numeric(0), 0, 1))
+  expect_equal(mod$run(0), matrix(1:10, 10, 1))
 })
 
 
@@ -152,7 +151,6 @@ test_that("reorder", {
                           quiet = TRUE)
 
   obj <- res$new(list(sd = 1), 0, 10)
-  obj$set_index(1)
   y1 <- obj$run(5)
 
   ## Simplest permutation:
@@ -180,7 +178,6 @@ test_that("reorder and duplicate", {
                           quiet = TRUE)
 
   obj <- res$new(list(sd = 1), 0, 10)
-  obj$set_index(1)
   y1 <- obj$run(5)
 
   index <- c(1L, 4L, 9L, 7L, 7L, 2L, 5L, 9L, 9L, 5L)
@@ -245,9 +242,6 @@ test_that("run in float mode", {
   n <- 1000
   obj_d <- res_d$new(list(sd = 10), 0, n)
   obj_f <- res_f$new(list(sd = 10), 0, n)
-
-  obj_d$set_index(1)
-  obj_f$set_index(1)
 
   y_d <- obj_d$run(10)
   y_f <- obj_f$run(10)

--- a/tests/testthat/test-example.R
+++ b/tests/testthat/test-example.R
@@ -4,6 +4,7 @@ test_that("create walk, stepping for one step", {
   res <- compile_and_load(dust_file("examples/walk.cpp"), "walk", "mywalk",
                           quiet = TRUE)
   obj <- res$new(list(sd = 1), 0, 10)
+  obj$set_index_y(1)
   expect_null(obj$info())
 
   y <- obj$run(1)
@@ -16,6 +17,7 @@ test_that("walk agrees with random number stream", {
   res <- compile_and_load(dust_file("examples/walk.cpp"), "walk", "mywalk",
                           quiet = TRUE)
   obj <- res$new(list(sd = 1), 0, 10, seed = 1L)
+  obj$set_index_y(1)
   y <- obj$run(5)
 
   cmp <- dust_rng$new(1, 1)$rnorm(50, 0, 1)
@@ -31,6 +33,7 @@ test_that("Reset particles and resume continues with rng", {
   sd2 <- 4
 
   obj <- res$new(list(sd = sd1), 0, 10)
+  obj$set_index_y(1)
 
   y1 <- obj$run(5)
   expect_equal(obj$step(), 5)
@@ -54,6 +57,7 @@ test_that("Basic sir model", {
                           quiet = TRUE)
 
   obj <- res$new(list(), 0, 100)
+  obj$set_index_y(1)
 
   ans <- vector("list", 150)
   for (i in seq_along(ans)) {
@@ -93,7 +97,7 @@ test_that("work with index_y", {
   res <- dust(dust_file("examples/variable.cpp"), quiet = TRUE)
   mod <- res$new(list(len = 10), 0, 1)
   expect_equal(mod$state(), matrix(1:10))
-  expect_equal(mod$run(0), matrix(1))
+  expect_equal(mod$run(0), matrix(numeric(), nrow = 0, ncol = 1))
 
   mod$set_index_y(2:4)
   expect_equal(mod$run(0), matrix(2:4))
@@ -109,6 +113,7 @@ test_that("reorder", {
                           quiet = TRUE)
 
   obj <- res$new(list(sd = 1), 0, 10)
+  obj$set_index_y(1)
   y1 <- obj$run(5)
 
   ## Simplest permutation:
@@ -136,6 +141,7 @@ test_that("reorder and duplicate", {
                           quiet = TRUE)
 
   obj <- res$new(list(sd = 1), 0, 10)
+  obj$set_index_y(1)
   y1 <- obj$run(5)
 
   index <- c(1L, 4L, 9L, 7L, 7L, 2L, 5L, 9L, 9L, 5L)
@@ -201,6 +207,9 @@ test_that("run in float mode", {
   obj_d <- res_d$new(list(sd = 10), 0, n)
   obj_f <- res_f$new(list(sd = 10), 0, n)
 
+  obj_d$set_index_y(1)
+  obj_f$set_index_y(1)
+
   y_d <- obj_d$run(10)
   y_f <- obj_f$run(10)
 
@@ -234,16 +243,19 @@ test_that("Basic threading test", {
     "n_generators must be a multiple of n_threads")
 
   obj <- res$new(list(sd = 1), 0, 10, n_threads = 2L, n_generators = 2L)
+  obj$set_index_y(1)
   y0 <- obj$state()
   y22_1 <- obj$run(5)
   y22_2 <- obj$state()
 
   ## And again without parallel
   obj <- res$new(list(sd = 1), 0, 10, n_threads = 1L, n_generators = 2L)
+  obj$set_index_y(1)
   y12_1 <- obj$run(5)
   y12_2 <- obj$state()
 
   obj <- res$new(list(sd = 1), 0, 10, n_threads = 1L, n_generators = 1L)
+  obj$set_index_y(1)
   y11_1 <- obj$run(5)
   y11_2 <- obj$state()
 

--- a/tests/testthat/test-example.R
+++ b/tests/testthat/test-example.R
@@ -108,6 +108,16 @@ test_that("work with index_y", {
 })
 
 
+test_that("reset clears the index", {
+  res <- dust(dust_file("examples/variable.cpp"), quiet = TRUE)
+  mod <- res$new(list(len = 10), 0, 1)
+  mod$set_index_y(2:4)
+  expect_equal(mod$run(0), matrix(2:4))
+  mod$reset(list(len = 10), 0)
+  expect_equal(mod$run(0), matrix(numeric(0), 0, 1))
+})
+
+
 test_that("set model state", {
   res <- dust(dust_file("examples/variable.cpp"), quiet = TRUE)
   mod <- res$new(list(len = 10), 0, 1)
@@ -122,7 +132,7 @@ test_that("set model state", {
 })
 
 
-test_that("set model state", {
+test_that("set model state into multiple particles", {
   res <- dust(dust_file("examples/variable.cpp"), quiet = TRUE)
   mod <- res$new(list(len = 10), 0, 20)
   expect_equal(mod$state(), matrix(1:10, 10, 20))

--- a/tests/testthat/test-example.R
+++ b/tests/testthat/test-example.R
@@ -108,6 +108,34 @@ test_that("work with index_y", {
 })
 
 
+test_that("set model state", {
+  res <- dust(dust_file("examples/variable.cpp"), quiet = TRUE)
+  mod <- res$new(list(len = 10), 0, 1)
+  expect_equal(mod$state(), matrix(1:10))
+  x <- runif(10)
+  mod$set_state(x)
+  expect_equal(mod$state(), matrix(x))
+  expect_error(
+    mod$set_state(1),
+    "Expected a vector with 10 elements for 'state'")
+  expect_equal(mod$state(), matrix(x))
+})
+
+
+test_that("set model state", {
+  res <- dust(dust_file("examples/variable.cpp"), quiet = TRUE)
+  mod <- res$new(list(len = 10), 0, 20)
+  expect_equal(mod$state(), matrix(1:10, 10, 20))
+  x <- runif(10)
+  mod$set_state(x)
+  expect_equal(mod$state(), matrix(x, 10, 20))
+  expect_error(
+    mod$set_state(1),
+    "Expected a vector with 10 elements for 'state'")
+  expect_equal(mod$state(), matrix(x, 10, 20))
+})
+
+
 test_that("reorder", {
   res <- compile_and_load(dust_file("examples/walk.cpp"), "walk", "mywalk",
                           quiet = TRUE)

--- a/tests/testthat/test-example.R
+++ b/tests/testthat/test-example.R
@@ -38,6 +38,7 @@ test_that("Reset particles and resume continues with rng", {
   y1 <- obj$run(5)
   expect_equal(obj$step(), 5)
   obj$reset(list(sd = sd2), 0)
+  obj$set_index_y(1)
   expect_equal(obj$step(), 0)
   y2 <- obj$run(5)
   expect_equal(obj$step(), 5)

--- a/tests/testthat/test-example.R
+++ b/tests/testthat/test-example.R
@@ -4,7 +4,7 @@ test_that("create walk, stepping for one step", {
   res <- compile_and_load(dust_file("examples/walk.cpp"), "walk", "mywalk",
                           quiet = TRUE)
   obj <- res$new(list(sd = 1), 0, 10)
-  obj$set_index_y(1)
+  obj$set_index(1)
   expect_null(obj$info())
 
   y <- obj$run(1)
@@ -17,7 +17,7 @@ test_that("walk agrees with random number stream", {
   res <- compile_and_load(dust_file("examples/walk.cpp"), "walk", "mywalk",
                           quiet = TRUE)
   obj <- res$new(list(sd = 1), 0, 10, seed = 1L)
-  obj$set_index_y(1)
+  obj$set_index(1)
   y <- obj$run(5)
 
   cmp <- dust_rng$new(1, 1)$rnorm(50, 0, 1)
@@ -33,12 +33,12 @@ test_that("Reset particles and resume continues with rng", {
   sd2 <- 4
 
   obj <- res$new(list(sd = sd1), 0, 10)
-  obj$set_index_y(1)
+  obj$set_index(1)
 
   y1 <- obj$run(5)
   expect_equal(obj$step(), 5)
   obj$reset(list(sd = sd2), 0)
-  obj$set_index_y(1)
+  obj$set_index(1)
   expect_equal(obj$step(), 0)
   y2 <- obj$run(5)
   expect_equal(obj$step(), 5)
@@ -58,7 +58,7 @@ test_that("Basic sir model", {
                           quiet = TRUE)
 
   obj <- res$new(list(), 0, 100)
-  obj$set_index_y(1)
+  obj$set_index(1)
 
   ans <- vector("list", 150)
   for (i in seq_along(ans)) {
@@ -94,13 +94,13 @@ test_that("Basic sir model", {
 })
 
 
-test_that("work with index_y", {
+test_that("set index", {
   res <- dust(dust_file("examples/variable.cpp"), quiet = TRUE)
   mod <- res$new(list(len = 10), 0, 1)
   expect_equal(mod$state(), matrix(1:10))
   expect_equal(mod$run(0), matrix(numeric(), nrow = 0, ncol = 1))
 
-  mod$set_index_y(2:4)
+  mod$set_index(2:4)
   expect_equal(mod$run(0), matrix(2:4))
 
   y <- mod$run(1)
@@ -112,7 +112,7 @@ test_that("work with index_y", {
 test_that("reset clears the index", {
   res <- dust(dust_file("examples/variable.cpp"), quiet = TRUE)
   mod <- res$new(list(len = 10), 0, 1)
-  mod$set_index_y(2:4)
+  mod$set_index(2:4)
   expect_equal(mod$run(0), matrix(2:4))
   mod$reset(list(len = 10), 0)
   expect_equal(mod$run(0), matrix(numeric(0), 0, 1))
@@ -152,7 +152,7 @@ test_that("reorder", {
                           quiet = TRUE)
 
   obj <- res$new(list(sd = 1), 0, 10)
-  obj$set_index_y(1)
+  obj$set_index(1)
   y1 <- obj$run(5)
 
   ## Simplest permutation:
@@ -180,7 +180,7 @@ test_that("reorder and duplicate", {
                           quiet = TRUE)
 
   obj <- res$new(list(sd = 1), 0, 10)
-  obj$set_index_y(1)
+  obj$set_index(1)
   y1 <- obj$run(5)
 
   index <- c(1L, 4L, 9L, 7L, 7L, 2L, 5L, 9L, 9L, 5L)
@@ -246,8 +246,8 @@ test_that("run in float mode", {
   obj_d <- res_d$new(list(sd = 10), 0, n)
   obj_f <- res_f$new(list(sd = 10), 0, n)
 
-  obj_d$set_index_y(1)
-  obj_f$set_index_y(1)
+  obj_d$set_index(1)
+  obj_f$set_index(1)
 
   y_d <- obj_d$run(10)
   y_f <- obj_f$run(10)
@@ -282,19 +282,19 @@ test_that("Basic threading test", {
     "n_generators must be a multiple of n_threads")
 
   obj <- res$new(list(sd = 1), 0, 10, n_threads = 2L, n_generators = 2L)
-  obj$set_index_y(1)
+  obj$set_index(1)
   y0 <- obj$state()
   y22_1 <- obj$run(5)
   y22_2 <- obj$state()
 
   ## And again without parallel
   obj <- res$new(list(sd = 1), 0, 10, n_threads = 1L, n_generators = 2L)
-  obj$set_index_y(1)
+  obj$set_index(1)
   y12_1 <- obj$run(5)
   y12_2 <- obj$state()
 
   obj <- res$new(list(sd = 1), 0, 10, n_threads = 1L, n_generators = 1L)
-  obj$set_index_y(1)
+  obj$set_index(1)
   y11_1 <- obj$run(5)
   y11_2 <- obj$state()
 

--- a/tests/testthat/test-package.R
+++ b/tests/testthat/test-package.R
@@ -15,11 +15,11 @@ test_that("validate package", {
   w <- res$env$walk$new(list(sd = 1), 0, 100)
   expect_equal(w$state(), matrix(0, 1, 100))
 
-  expect_equal(w$run(0), matrix(numeric(0), 0, 100))
-  w$set_index(1)
   expect_equal(w$run(0), matrix(0, 1, 100))
   w$set_state(pi)
   expect_equal(w$run(0), matrix(pi, 1, 100))
+  w$set_index(integer(0))
+  expect_equal(w$run(0), matrix(0, 0, 100))
 
   rm(w)
   gc()

--- a/tests/testthat/test-package.R
+++ b/tests/testthat/test-package.R
@@ -14,6 +14,13 @@ test_that("validate package", {
   res <- pkgload::load_all(path)
   w <- res$env$walk$new(list(sd = 1), 0, 100)
   expect_equal(w$state(), matrix(0, 1, 100))
+
+  expect_equal(w$run(0), matrix(numeric(0), 0, 100))
+  w$set_index_y(1)
+  expect_equal(w$run(0), matrix(0, 1, 100))
+  w$set_state(pi)
+  expect_equal(w$run(0), matrix(pi, 1, 100))
+
   rm(w)
   gc()
   pkgload::unload("pkg")

--- a/tests/testthat/test-package.R
+++ b/tests/testthat/test-package.R
@@ -16,7 +16,7 @@ test_that("validate package", {
   expect_equal(w$state(), matrix(0, 1, 100))
 
   expect_equal(w$run(0), matrix(numeric(0), 0, 100))
-  w$set_index_y(1)
+  w$set_index(1)
   expect_equal(w$run(0), matrix(0, 1, 100))
   w$set_state(pi)
   expect_equal(w$run(0), matrix(pi, 1, 100))


### PR DESCRIPTION
This PR allows setting the "index" (the filter applied to the state vector after run) and also the state.

There is some subtlety here. We do not know the *size* of the problem until after the model object has been created (i.e., `data_t` passed to the model constructor) and that is done in a block of code that should not throw.  So we set `data` and `step` here, but change `index` and `state` in a function that must be applied *after* this has happened. So either after a creation or a reset one can use `set_index` or `set_state`. The default index is now a much more sensible empty vector, default state is that implied by the model.

I have updated `index_y` to `index` everywhere as it did not feel that was adding much benefit. Later we may rename again to `index_run` in contrast with any other indices that we store (in the outside chance that checking the index is a bottleneck).

I've bumped the version number to 0.1.0 as this gets close to a MVP and should be stable enough to start work again on mcstate.

Fixes #8 
Fixes #6 