### PR TITLE
i45: allow variable initial time

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dust
 Title: Iterate Multiple Realisations of Stochastic Models
-Version: 0.1.1
+Version: 0.1.2
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("John", "Lees", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# dust 0.1.2
+
+* Allow `$set_state()` to accept an initial step too. This can be a vector if particles start at different initial steps, in which case all particles are run up to the latest step (#45)
+
 # dust 0.1.1
 
 * Allow `$set_state()` to accept a matrix in order to start particles with different starting values (#43)

--- a/R/dust_class.R
+++ b/R/dust_class.R
@@ -85,7 +85,12 @@ dust_class <- R6::R6Class(
     ##' many rows as your model's state and as many columns as you have
     ##' particles (in which case you can set a number of different starting
     ##' states at once).
-    set_state = function(state) {
+    ##'
+    ##' @param step If not `NULL`, then this sets the initial step. If this
+    ##' is a vector (with the same length as the number of particles), then
+    ##' particles are started from different initial steps and run up to the
+    ##' larges step given (i.e., `max(step)`)
+    set_state = function(state, step = NULL) {
     },
 
     ##' @description

--- a/inst/include/dust/dust.hpp
+++ b/inst/include/dust/dust.hpp
@@ -59,6 +59,10 @@ public:
     std::swap(_y, _y_swap);
   }
 
+  void set_step(const size_t step) {
+    _step = step;
+  }
+
   void set_state(const Particle<T> other) {
     _y_swap = other._y;
   }
@@ -114,6 +118,24 @@ public:
       if (is_matrix) {
         it += n_state;
       }
+    }
+  }
+
+  void set_step(const size_t step) {
+    const size_t n_particles = _particles.size();
+    for (size_t i = 0; i < n_particles; ++i) {
+      _particles[i].set_step(step);
+    }
+  }
+
+  void set_step(const std::vector<size_t>& step) {
+    const size_t n_particles = _particles.size();
+    for (size_t i = 0; i < n_particles; ++i) {
+      _particles[i].set_step(step[i]);
+    }
+    const auto r = std::minmax_element(step.begin(), step.end());
+    if (*r.second > *r.first) {
+      run(*r.second);
     }
   }
 

--- a/inst/include/dust/dust.hpp
+++ b/inst/include/dust/dust.hpp
@@ -3,6 +3,7 @@
 
 #include <dust/rng.hpp>
 
+#include <algorithm>
 #include <utility>
 #ifdef _OPENMP
 #if _OPENMP >= 201511

--- a/inst/include/dust/interface.hpp
+++ b/inst/include/dust/interface.hpp
@@ -52,7 +52,7 @@ void dust_set_state(SEXP ptr, SEXP r_state, SEXP r_step) {
   std::vector<size_t> step;
   if (r_step != R_NilValue) {
     step = validate_size(Rcpp::as<Rcpp::IntegerVector>(r_step), "step");
-    if (!(step.size() == 1 || step.size() != obj->n_particles())) {
+    if (!(step.size() == 1 || step.size() == obj->n_particles())) {
       Rcpp::stop("Expected 'size' to be scalar or length %d",
                  obj->n_particles());
     }

--- a/inst/include/dust/interface.hpp
+++ b/inst/include/dust/interface.hpp
@@ -8,6 +8,8 @@ typename Rcpp::RObject dust_info(const typename T::init_t& data);
 
 inline void validate_n(size_t n_generators, size_t n_threads);
 inline void validate_size(int x, const char * name);
+inline std::vector<size_t> validate_size(Rcpp::IntegerVector x,
+                                         const char *name);
 inline std::vector<size_t> r_index_to_index(Rcpp::IntegerVector r_index,
                                             size_t nmax);
 
@@ -41,12 +43,31 @@ void dust_set_index(SEXP ptr, Rcpp::IntegerVector r_index) {
 }
 
 template <typename T>
-void dust_set_state(SEXP ptr, SEXP r_state) {
+void dust_set_state(SEXP ptr, SEXP r_state, SEXP r_step) {
   Dust<T> *obj = Rcpp::as<Rcpp::XPtr<Dust<T>>>(ptr);
+
+  // Do the validation here so that we leave this function having
+  // dealt with both or neither (i.e., do not fail on step after
+  // succeeding on state).
+  std::vector<size_t> step;
+  if (r_step != R_NilValue) {
+    step = validate_size(Rcpp::as<Rcpp::IntegerVector>(r_step), "step");
+    if (!(step.size() == 1 || step.size() != obj->n_particles())) {
+      Rcpp::stop("Expected 'size' to be scalar or length %d",
+                 obj->n_particles());
+    }
+  }
+
   if (Rf_isMatrix(r_state)) {
     dust_set_state(obj, Rcpp::as<Rcpp::NumericMatrix>(r_state));
   } else {
     dust_set_state(obj, Rcpp::as<Rcpp::NumericVector>(r_state));
+  }
+
+  if (step.size() == 1) {
+    obj->set_step(step[0]);
+  } else if (step.size() > 1) {
+    obj->set_step(step);
   }
 }
 
@@ -176,6 +197,21 @@ inline void validate_size(int x, const char * name) {
   if (x < 0) {
     Rcpp::stop("%s must be non-negative", name);
   }
+}
+
+inline std::vector<size_t> validate_size(Rcpp::IntegerVector r_x,
+                                         const char * name) {
+  const size_t n = static_cast<size_t>(r_x.size());
+  std::vector<size_t> x;
+  x.reserve(n);
+  for (size_t i = 0; i < n; ++i) {
+    int el = r_x[i];
+    if (el < 0) {
+      Rcpp::stop("All elements of '%s' must be non-negative", name);
+    }
+    x.push_back(el);
+  }
+  return x;
 }
 
 inline std::vector<size_t> r_index_to_index(Rcpp::IntegerVector r_index,

--- a/inst/template/dust.R.template
+++ b/inst/template/dust.R.template
@@ -82,8 +82,13 @@
     ##' many rows as your model's state and as many columns as you have
     ##' particles (in which case you can set a number of different starting
     ##' states at once).
-    set_state = function(state) {
-      dust_{{name}}_set_state(private$ptr, state)
+    ##'
+    ##' @param step If not `NULL`, then this sets the initial step. If this
+    ##' is a vector (with the same length as the number of particles), then
+    ##' particles are started from different initial steps and run up to the
+    ##' larges step given (i.e., `max(step)`)
+    set_state = function(state, step = NULL) {
+      dust_{{name}}_set_state(private$ptr, state, step)
     },
 
     ##' @description

--- a/inst/template/dust.cpp
+++ b/inst/template/dust.cpp
@@ -22,8 +22,8 @@ SEXP dust_{{name}}_set_index(SEXP ptr, Rcpp::IntegerVector r_index) {
 }
 
 // [[Rcpp::export(rng = false)]]
-SEXP dust_{{name}}_set_state(SEXP ptr, SEXP r_state) {
-  dust_set_state<{{type}}>(ptr, r_state);
+SEXP dust_{{name}}_set_state(SEXP ptr, SEXP r_state, SEXP r_step) {
+  dust_set_state<{{type}}>(ptr, r_state, r_step);
   return R_NilValue;
 }
 

--- a/man/dust.Rd
+++ b/man/dust.Rd
@@ -256,7 +256,7 @@ validated, and an error thrown if an invalid index is given).}
 Set the "state" vector for all particles, overriding whatever your
 models \code{initial()} method provides.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{dust_class$set_state(state)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{dust_class$set_state(state, step = NULL)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -268,6 +268,11 @@ state is applied to all particles), or a numeric matrix with as
 many rows as your model's state and as many columns as you have
 particles (in which case you can set a number of different starting
 states at once).}
+
+\item{\code{step}}{If not \code{NULL}, then this sets the initial step. If this
+is a vector (with the same length as the number of particles), then
+particles are started from different initial steps and run up to the
+larges step given (i.e., \code{max(step)})}
 }
 \if{html}{\out{</div>}}
 }

--- a/tests/testthat/test-example.R
+++ b/tests/testthat/test-example.R
@@ -349,3 +349,31 @@ test_that("cache hits do not compile", {
   ## Same object
   expect_identical(res, cmp)
 })
+
+
+test_that("set model state and time, varying time", {
+  res <- dust(dust_file("examples/variable.cpp"), quiet = TRUE)
+  mod <- res$new(list(len = 10), 0, 2)
+  m <- matrix(rep(1:2, each = 10), 10, 2)
+  step <- 0:1
+  mod$set_state(m, step)
+  cmp <- dust_rng$new(1, 1)$rnorm(10, 0, 1)
+
+  state <- mod$state()
+  expect_equal(mod$step(), 1)
+  expect_equal(state[, 2], m[, 2])
+  expect_equal(state[, 1], m[, 1] + cmp)
+})
+
+
+test_that("set model state and time, constant time", {
+  res <- dust(dust_file("examples/variable.cpp"), quiet = TRUE)
+  mod <- res$new(list(len = 10), 0, 2)
+  m <- matrix(runif(20), 10, 2)
+  step <- 10
+  mod$set_state(m, step)
+
+  state <- mod$state()
+  expect_equal(mod$step(), 10)
+  expect_equal(state, m)
+})

--- a/vignettes/dust.Rmd
+++ b/vignettes/dust.Rmd
@@ -297,6 +297,55 @@ matplot(time, state, type = "l", lty = 1, col = "#00000022",
         xlab = "Time", ylab = "Number infected (I)")
 ```
 
+You can optionally set the initial step at the same time as the state. This is useful in two cases; if your model depends on time (e.g., you use the step in a calculation by transforming it into some measure of time) or if your particles start at different points. For example, suppose we start 10 individuals in the infected state but we do so with a number of possible starting points sampled from between step 0 and step 30:
+
+```{r initial_step}
+step0 <- sample(0:30, 20, replace = TRUE)
+model <- sir$new(list(), 0, 20)
+model$set_state(c(1000, 10, 0), step0)
+```
+
+After initialisation, our model is now at `r max(step0)`, the last step referenced in `step0`
+
+```{r}
+model$step()
+```
+
+and the initial states are a mix of states, despite having been seeded with the same 10 infected individuals, as different particles have run for the same time to reach this time point:
+
+```{r}
+model$state()
+```
+
+From this point we can continue to run the simulation as before:
+
+```{r}
+model$set_index(2)
+steps <- seq(max(step0), 600, by = 5)
+state <- run_dust(model, steps)
+time <- steps / 4
+matplot(time, state, type = "l", lty = 1, col = "#00000022",
+        xlab = "Time", ylab = "Number infected (I)")
+```
+
+You can also set the initial state to a range of different values. Suppose we set the initial number of infections to be poisson distributed with a mean of 10, we might write:
+
+```{r}
+I0 <- rpois(20, 10)
+state0 <- rbind(1010 - I0, I0, 0, deparse.level = 0)
+model$set_state(state0, 0)
+model$step()
+model$state()
+```
+
+Here, we have our variable initial state and all particles starting at step 0. You can combine the two approaches to have a variable initial state and variable initial time by running
+
+```{r}
+model$set_state(state0, step0)
+model$step()
+model$state()
+```
+
 ### Reset the model
 
 A model can be "reset" rather than recreated. This is important in a simulation context because if you recreate the model you will reset the seed. So if you are performing stochastic realisations you should continue with your random number stream, not start again from the same seed.

--- a/vignettes/dust.Rmd
+++ b/vignettes/dust.Rmd
@@ -311,7 +311,7 @@ After initialisation, our model is now at `r max(step0)`, the last step referenc
 model$step()
 ```
 
-and the initial states are a mix of states, despite having been seeded with the same 10 infected individuals, as different particles have run for the same time to reach this time point:
+and the initial states are a mix of states, despite having been seeded with the same 10 infected individuals, as different particles have run for different numbers of steps to reach this common time point:
 
 ```{r}
 model$state()


### PR DESCRIPTION
This PR allows for a "burnin" period in particles, where we accept a variable initial time. This is needed for the sircovid work because we allow the precice seeding date to be drawn from a truncated poisson distribution. To do this we allow multiple a variable step but as part of the initialisation we run all particles up to the largest step given. No observation of the process can be added during this period so it's not possible to get a trace of the particles (probably something to consider when doing #7)

Fixes #45 