### PR TITLE
i48: null state

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dust
 Title: Iterate Multiple Realisations of Stochastic Models
-Version: 0.1.2
+Version: 0.1.3
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("John", "Lees", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# dust 0.1.3
+
+* Allow `$set_state()` to accept an initial state of `NULL`, in which case only the time is set (#48)
+
 # dust 0.1.2
 
 * Allow `$set_state()` to accept an initial step too. This can be a vector if particles start at different initial steps, in which case all particles are run up to the latest step (#45)

--- a/inst/include/dust/interface.hpp
+++ b/inst/include/dust/interface.hpp
@@ -58,10 +58,12 @@ void dust_set_state(SEXP ptr, SEXP r_state, SEXP r_step) {
     }
   }
 
-  if (Rf_isMatrix(r_state)) {
-    dust_set_state(obj, Rcpp::as<Rcpp::NumericMatrix>(r_state));
-  } else {
-    dust_set_state(obj, Rcpp::as<Rcpp::NumericVector>(r_state));
+  if (r_state != R_NilValue) {
+    if (Rf_isMatrix(r_state)) {
+      dust_set_state(obj, Rcpp::as<Rcpp::NumericMatrix>(r_state));
+    } else {
+      dust_set_state(obj, Rcpp::as<Rcpp::NumericVector>(r_state));
+    }
   }
 
   if (step.size() == 1) {

--- a/tests/testthat/test-example.R
+++ b/tests/testthat/test-example.R
@@ -390,3 +390,21 @@ test_that("set model time but not state", {
   expect_equal(mod$step(), 10)
   expect_equal(mod$state(), matrix(1:10, 10, 2))
 })
+
+
+test_that("NULL state leaves state untouched", {
+  res <- dust(dust_file("examples/variable.cpp"), quiet = TRUE)
+  mod <- res$new(list(len = 10), 0, 2)
+  m <- matrix(runif(20), 10, 2)
+  mod$set_state(m, NULL)
+  expect_equal(mod$state(), m)
+  expect_equal(mod$step(), 0)
+
+  mod$set_state(NULL, 10)
+  expect_equal(mod$state(), m)
+  expect_equal(mod$step(), 10)
+
+  mod$set_state(NULL, NULL)
+  expect_equal(mod$state(), m)
+  expect_equal(mod$step(), 10)
+})

--- a/tests/testthat/test-example.R
+++ b/tests/testthat/test-example.R
@@ -377,3 +377,16 @@ test_that("set model state and time, constant time", {
   expect_equal(mod$step(), 10)
   expect_equal(state, m)
 })
+
+
+test_that("set model time but not state", {
+  res <- dust(dust_file("examples/variable.cpp"), quiet = TRUE)
+  mod <- res$new(list(len = 10), 0, 2)
+  expect_null(mod$set_state(NULL, NULL))
+  expect_equal(mod$step(), 0)
+  expect_equal(mod$state(), matrix(1:10, 10, 2))
+
+  expect_null(mod$set_state(NULL, 10))
+  expect_equal(mod$step(), 10)
+  expect_equal(mod$state(), matrix(1:10, 10, 2))
+})


### PR DESCRIPTION
This PR allows

```
$set_state(NULL, step)
```

to set the `step` but leave state untouched. This turned out to be needed in wiring up the mcstate stuff. We could currently do this by rerunning `$reset(data, step)` but that will cause all the particles to be reallocated

Fixes #48