### PR TITLE
i51: many rng

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dust
 Title: Iterate Multiple Realisations of Stochastic Models
-Version: 0.1.4
+Version: 0.1.5
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("John", "Lees", role = "aut"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dust
 Title: Iterate Multiple Realisations of Stochastic Models
-Version: 0.1.3
+Version: 0.1.4
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("John", "Lees", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # dust 0.1.3
 
+* New function `dust::dust_simulate` which provides a helper for running a simulation while collecting output (#7)
+
+# dust 0.1.3
+
 * Allow `$set_state()` to accept an initial state of `NULL`, in which case only the time is set (#48)
 
 # dust 0.1.2

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,8 @@
-# dust 0.1.3
+# dust 0.1.5
+
+* Simpler RNG interface; we now always use as many RNG streams as there are particles (#51)
+
+# dust 0.1.4
 
 * New function `dust::dust_simulate` which provides a helper for running a simulation while collecting output (#7)
 

--- a/R/dust_class.R
+++ b/R/dust_class.R
@@ -31,20 +31,15 @@ dust_class <- R6::R6Class(
     ##' least 1
     ##'
     ##' @param n_threads Number of OMP threads to use, if `dust` and
-    ##' your model were compiled with OMP support (details to come)
-    ##'
-    ##' @param n_generators The number of random number generators to
-    ##' use. Must be at least `n_threads` and a multiple of
-    ##' `n_threads`.  You can use this to ensure reproducible results
-    ##' when changing the number of threads, while preserving
-    ##' statistically reasonable random numbers (for example setting
-    ##' `n_generators = 64` and then using 1, 2, 4, 8, ..., 64 threads
-    ##' as your computational capacity allows).
+    ##' your model were compiled with OMP support (details to come).
+    ##' `n_particles` should be a multiple of `n_threads` (e.g., if you use 8
+    ##' threads, then you should have 8, 16, 24, etc particles). However, this
+    ##' is not compulsary.
     ##'
     ##' @param seed Seed to use for the random number generator
     ##' (positive integer)
     initialize = function(data, step, n_particles, n_threads = 1L,
-                          n_generators = 1L, seed = 1L) {
+                          seed = 1L) {
     },
 
     ##' @description

--- a/inst/include/dust/dust.hpp
+++ b/inst/include/dust/dust.hpp
@@ -90,11 +90,10 @@ public:
   typedef typename T::real_t real_t;
   typedef typename dust::RNG<real_t, int_t> rng_t;
 
-  Dust(const init_t data, const size_t step,
-       const size_t n_particles, const size_t n_threads,
-       const size_t n_generators, const size_t seed) :
+  Dust(const init_t data, const size_t step, const size_t n_particles,
+       const size_t n_threads, const size_t seed) :
     _n_threads(n_threads),
-    _rng(n_generators, seed) {
+    _rng(n_particles, seed) {
     initialise(data, step, n_particles);
   }
 

--- a/inst/include/dust/interface.hpp
+++ b/inst/include/dust/interface.hpp
@@ -6,7 +6,6 @@ typename T::init_t dust_data(Rcpp::List data);
 template <typename T>
 typename Rcpp::RObject dust_info(const typename T::init_t& data);
 
-inline void validate_n(size_t n_generators, size_t n_threads);
 inline void validate_size(int x, const char * name);
 inline std::vector<size_t> validate_size(Rcpp::IntegerVector x,
                                          const char *name);
@@ -16,18 +15,15 @@ inline std::vector<size_t> r_index_to_index(Rcpp::IntegerVector r_index,
 template <typename T>
 Rcpp::List dust_alloc(Rcpp::List r_data, int step,
                       int n_particles, int n_threads,
-                      int n_generators, int seed) {
+                      int seed) {
   validate_size(step, "step");
   validate_size(n_particles, "n_particles");
   validate_size(n_threads, "n_threads");
-  validate_size(n_generators, "n_generators");
   validate_size(seed, "seed");
-  validate_n(n_generators, n_threads);
 
   typename T::init_t data = dust_data<T>(r_data);
 
-  Dust<T> *d =
-    new Dust<T>(data, step, n_particles, n_threads, n_generators, seed);
+  Dust<T> *d = new Dust<T>(data, step, n_particles, n_threads, seed);
   Rcpp::XPtr<Dust<T>> ptr(d, false);
   Rcpp::RObject info = dust_info<T>(data);
 
@@ -184,15 +180,6 @@ void dust_reorder(SEXP ptr, Rcpp::IntegerVector r_index) {
 template <typename T>
 Rcpp::RObject dust_info(const typename T::init_t& data) {
   return R_NilValue;
-}
-
-inline void validate_n(size_t n_generators, size_t n_threads) {
-  if (n_generators < n_threads) {
-    Rcpp::stop("n_generators must be at least n_threads");
-  }
-  if (n_generators % n_threads > 0) {
-    Rcpp::stop("n_generators must be a multiple of n_threads");
-  }
 }
 
 inline void validate_size(int x, const char * name) {

--- a/inst/template/dust.R.template
+++ b/inst/template/dust.R.template
@@ -21,22 +21,17 @@
     ##' least 1
     ##'
     ##' @param n_threads Number of OMP threads to use, if `dust` and
-    ##' your model were compiled with OMP support (details to come)
-    ##'
-    ##' @param n_generators The number of random number generators to
-    ##' use. Must be at least `n_threads` and a multiple of
-    ##' `n_threads`.  You can use this to ensure reproducible results
-    ##' when changing the number of threads, while preserving
-    ##' statistically reasonable random numbers (for example setting
-    ##' `n_generators = 64` and then using 1, 2, 4, 8, ..., 64 threads
-    ##' as your computational capacity allows).
+    ##' your model were compiled with OMP support (details to come).
+    ##' `n_particles` should be a multiple of `n_threads` (e.g., if you use 8
+    ##' threads, then you should have 8, 16, 24, etc particles). However, this
+    ##' is not compulsary.
     ##'
     ##' @param seed Seed to use for the random number generator
     ##' (positive integer)
     initialize = function(data, step, n_particles, n_threads = 1L,
-                          n_generators = 1L, seed = 1L) {
+                          seed = 1L) {
       res <- dust_{{name}}_alloc(data, step, n_particles,
-                        n_threads, n_generators, seed)
+                        n_threads, seed)
       private$ptr <- res[[1L]]
       private$data <- res[[2L]]
     },

--- a/inst/template/dust.cpp
+++ b/inst/template/dust.cpp
@@ -5,9 +5,8 @@
 
 // [[Rcpp::export(rng = false)]]
 SEXP dust_{{name}}_alloc(Rcpp::List r_data, size_t step, size_t n_particles,
-                size_t n_threads, size_t n_generators, size_t seed) {
-  return dust_alloc<{{type}}>(r_data, step, n_particles, n_threads,
-                              n_generators, seed);
+                size_t n_threads, size_t seed) {
+  return dust_alloc<{{type}}>(r_data, step, n_particles, n_threads, seed);
 }
 
 // [[Rcpp::export(rng = false)]]

--- a/man/dust.Rd
+++ b/man/dust.Rd
@@ -157,14 +157,7 @@ obj$state()
 \subsection{Method \code{new()}}{
 Create a new model
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{dust_class$new(
-  data,
-  step,
-  n_particles,
-  n_threads = 1L,
-  n_generators = 1L,
-  seed = 1L
-)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{dust_class$new(data, step, n_particles, n_threads = 1L, seed = 1L)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -180,15 +173,10 @@ your model.}
 least 1}
 
 \item{\code{n_threads}}{Number of OMP threads to use, if \code{dust} and
-your model were compiled with OMP support (details to come)}
-
-\item{\code{n_generators}}{The number of random number generators to
-use. Must be at least \code{n_threads} and a multiple of
-\code{n_threads}.  You can use this to ensure reproducible results
-when changing the number of threads, while preserving
-statistically reasonable random numbers (for example setting
-\code{n_generators = 64} and then using 1, 2, 4, 8, ..., 64 threads
-as your computational capacity allows).}
+your model were compiled with OMP support (details to come).
+\code{n_particles} should be a multiple of \code{n_threads} (e.g., if you use 8
+threads, then you should have 8, 16, 24, etc particles). However, this
+is not compulsary.}
 
 \item{\code{seed}}{Seed to use for the random number generator
 (positive integer)}

--- a/tests/testthat/test-example.R
+++ b/tests/testthat/test-example.R
@@ -303,8 +303,13 @@ test_that("Basic threading test", {
   expect_equal(y12_1[1, ], y12_2[1, ])
 
   if (has_openmp() && y0[2, 1] == 1) {
-    ## OMP is enabled
-    expect_equal(y22_2[2, ], rep(0:1, 5))
+    ## OMP is enabled (note: this relies on implementation details of
+    ## openmp and we'd need to change this for a CRAN release - what
+    ## we'd expect to see is that 0 and 1 are both present, but as
+    ## we're leaving it up to the compiler to set the schedule I
+    ## believe this is not reliable theoretically, even though it is
+    ## empirically)
+    expect_equal(y22_2[2, ], rep(0:1, each = 5))
   } else {
     expect_equal(y22_2[2, ], rep(-1, 10))
   }

--- a/tests/testthat/test-example.R
+++ b/tests/testthat/test-example.R
@@ -7,7 +7,7 @@ test_that("create walk, stepping for one step", {
   expect_null(obj$info())
 
   y <- obj$run(1)
-  cmp <- dust_rng$new(1, 1)$rnorm(10, 0, 1)
+  cmp <- dust_rng$new(1, 10)$rnorm(10, 0, 1)
   expect_identical(drop(y), cmp)
 })
 
@@ -18,8 +18,8 @@ test_that("walk agrees with random number stream", {
   obj <- res$new(list(sd = 1), 0, 10, seed = 1L)
   y <- obj$run(5)
 
-  cmp <- dust_rng$new(1, 1)$rnorm(50, 0, 1)
-  expect_equal(drop(y), colSums(matrix(cmp, 5, 10)))
+  cmp <- dust_rng$new(1, 10)$rnorm(50, 0, 1)
+  expect_equal(drop(y), colSums(matrix(cmp, 5, 10, byrow = TRUE)))
   expect_identical(obj$state(), y)
 })
 
@@ -40,9 +40,9 @@ test_that("Reset particles and resume continues with rng", {
   expect_equal(obj$step(), 5)
 
   ## Then draw the random numbers:
-  cmp <- dust_rng$new(1, 1)$rnorm(100, 0, 1)
-  m1 <- matrix(cmp[1:50], 5, 10)
-  m2 <- matrix(cmp[51:100], 5, 10)
+  cmp <- dust_rng$new(1, 10)$rnorm(100, 0, 1)
+  m1 <- matrix(cmp[1:50], 5, 10, byrow = TRUE)
+  m2 <- matrix(cmp[51:100], 5, 10, byrow = TRUE)
 
   expect_equal(drop(y1), colSums(m1) * sd1)
   expect_equal(drop(y2), colSums(m2) * sd2)
@@ -179,10 +179,10 @@ test_that("reorder", {
 
   y3 <- obj$run(10)
 
-  cmp <- dust_rng$new(1, 1)$rnorm(100, 0, 1)
-  m1 <- matrix(cmp[1:50], 5, 10)
+  cmp <- dust_rng$new(1, 10)$rnorm(100, 0, 1)
+  m1 <- matrix(cmp[1:50], 5, 10, byrow = TRUE)
   m2 <- m1[, index]
-  m3 <- matrix(cmp[51:100], 5, 10)
+  m3 <- matrix(cmp[51:100], 5, 10, byrow = TRUE)
 
   expect_equal(drop(y1), colSums(m1))
   expect_equal(drop(y2), colSums(m2))
@@ -205,10 +205,10 @@ test_that("reorder and duplicate", {
 
   y3 <- obj$run(10)
 
-  cmp <- dust_rng$new(1, 1)$rnorm(100, 0, 1)
-  m1 <- matrix(cmp[1:50], 5, 10)
+  cmp <- dust_rng$new(1, 10)$rnorm(100, 0, 1)
+  m1 <- matrix(cmp[1:50], 5, 10, byrow = TRUE)
   m2 <- m1[, index]
-  m3 <- matrix(cmp[51:100], 5, 10)
+  m3 <- matrix(cmp[51:100], 5, 10, byrow = TRUE)
 
   expect_equal(drop(y1), colSums(m1))
   expect_equal(drop(y2), colSums(m2))
@@ -285,34 +285,22 @@ test_that("reset changes info", {
 test_that("Basic threading test", {
   res <- compile_and_load(dust_file("examples/parallel.cpp"), "parallel",
                           "myparallel", quiet = TRUE)
-  expect_error(
-    res$new(list(sd = 1), 0, 10, n_threads = 2L),
-    "n_generators must be at least n_threads")
-  expect_error(
-    res$new(list(sd = 1), 0, 10, n_threads = 2L, n_generators = 3L),
-    "n_generators must be a multiple of n_threads")
 
-  obj <- res$new(list(sd = 1), 0, 10, n_threads = 2L, n_generators = 2L)
+  obj <- res$new(list(sd = 1), 0, 10, n_threads = 2L)
   obj$set_index(1)
   y0 <- obj$state()
   y22_1 <- obj$run(5)
   y22_2 <- obj$state()
 
   ## And again without parallel
-  obj <- res$new(list(sd = 1), 0, 10, n_threads = 1L, n_generators = 2L)
+  obj <- res$new(list(sd = 1), 0, 10, n_threads = 1L)
   obj$set_index(1)
   y12_1 <- obj$run(5)
   y12_2 <- obj$state()
 
-  obj <- res$new(list(sd = 1), 0, 10, n_threads = 1L, n_generators = 1L)
-  obj$set_index(1)
-  y11_1 <- obj$run(5)
-  y11_2 <- obj$state()
-
   ## Quick easy check:
   expect_equal(y22_1[1, ], y22_2[1, ])
   expect_equal(y12_1[1, ], y12_2[1, ])
-  expect_equal(y11_1[1, ], y11_2[1, ])
 
   if (has_openmp() && y0[2, 1] == 1) {
     ## OMP is enabled
@@ -322,7 +310,6 @@ test_that("Basic threading test", {
   }
 
   expect_equal(y22_1, y12_1)
-  expect_equal(y22_1[c(1, 3, 5, 7, 9)], y11_1[1:5])
 })
 
 

--- a/tests/testthat/test-simulate.R
+++ b/tests/testthat/test-simulate.R
@@ -3,12 +3,16 @@ context("simulate")
 test_that("simulate simple walk", {
   res <- compile_and_load(dust_file("examples/walk.cpp"), "walk", "mywalk",
                           quiet = TRUE)
-  obj <- res$new(list(sd = 1), 0, 10)
-  m <- dust_simulate(obj, 0:100)
-  expect_equal(dim(m), c(1, 10, 101))
+  ns <- 100
+  np <- 10
+
+  obj <- res$new(list(sd = 1), 0, np)
+  m <- dust_simulate(obj, 0:ns)
+  expect_equal(dim(m), c(1, np, ns + 1))
 
   ## Compare against the direct version:
-  rand <- matrix(dust_rng$new(1)$rnorm(10 * 100, 0, 1), 10, 100)
+  rng <- dust_rng$new(1, np)
+  rand <- matrix(rng$rnorm(np * ns, 0, 1), np, ns)
   expect_equal(t(rbind(0, apply(rand, 1, cumsum))),
                drop(m))
 })

--- a/vignettes/dust.Rmd
+++ b/vignettes/dust.Rmd
@@ -112,28 +112,23 @@ curve(dnorm(x, 0, 10), col = "orange", add = TRUE, lwd = 2)
 
 ### Running a model in parallel
 
-The approach above still runs everything in serial, one particle after another. We can configure this system to run in parallel by providing two extra arguments to the constructor:
-
-* `n_generators`: the number of independent random number generators to use
-* `n_threads`: the number of threads to run on
-
-The idea here is that you set `n_generators` to be the maximum number of threads you might ever run the model on (say, 32) and `n_threads` to the number of threads that you want to use now (say, 4).  Subject to the constraint that `n_generators` is divisible by `n_threads` you will then get the same results as you change the number of available threads. If you change the number of generators you will get different results.  See `vignette("rng")` for more detail.
+The approach above still runs everything in serial, one particle after another. We can configure this system to run in parallel by providing the extra argument `n_threads` to the constructor.
 
 Provided that your system can compile with openmp the following code will execute in parallel using 2 threads
 
 ```{r, walk_parallel}
-model <- walk$new(list(sd = 1), 0, 20, n_generators = 8, n_threads = 2)
+model <- walk$new(list(sd = 1), 0, 20, n_threads = 2)
 model$run(100)
 ```
 
 Running this same code in series will give the same results:
 
 ```{r, walk_serial}
-model <- walk$new(list(sd = 1), 0, 20, n_generators = 8, n_threads = 1)
+model <- walk$new(list(sd = 1), 0, 20, n_threads = 1)
 model$run(100)
 ```
 
-If run in parallel with `k` threads then particles 1, 2, ..., k will be run first, one per thread, followed by k+1, ..., 2k and so on.  If you have more generators than threads then each thread will cycle through a set of generators but never use another thread's generator.
+We use as many random number generators as their are threads, so if you run fewer particles or more, increase the threads or decrease, the results will be the same.
 
 ## A more interesting example
 


### PR DESCRIPTION
This PR simplifies the RNG handling so that we always allocate `n_particles` RNGs and cycle through them. This eliminates any chance of race conditions without our previous fight with OpenMP version. It also means that as one adds and removes particles, except for the shuffling, the simulation is unchanged for the shared particles.

Fixes #51 