### PR TITLE
i56: tolerate cpp11 files

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dust
 Title: Iterate Multiple Realisations of Stochastic Models
-Version: 0.2.0
+Version: 0.2.1
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("John", "Lees", role = "aut"),

--- a/R/interface.R
+++ b/R/interface.R
@@ -168,10 +168,13 @@ dust_workdir <- function(path) {
     contents <- c(
       dir(path, all.files = TRUE, no.. = TRUE),
       file.path("src", dir(file.path(path, "src"),
+                           all.files = TRUE, no.. = TRUE)),
+      file.path("R", dir(file.path(path, "R"),
                            all.files = TRUE, no.. = TRUE)))
     contents <- contents[!grepl(".+\\.(o|so|dll)", contents)]
-    allowed <- c("DESCRIPTION", "NAMESPACE", "src",
-                 "src/Makevars", "src/dust.cpp")
+    allowed <- c("DESCRIPTION", "NAMESPACE", "src", "R",
+                 "src/Makevars", "src/dust.cpp", "R/dust.R",
+                 "src/cpp11.cpp", "R/cpp11.R")
     extra <- setdiff(contents, allowed)
     if (length(extra)) {
       stop(sprintf("Path '%s' does not look like a dust directory", path))

--- a/tests/testthat/test-interface.R
+++ b/tests/testthat/test-interface.R
@@ -66,7 +66,10 @@ test_that("dust_workdir allows existing dusty directories", {
   p <- tempfile()
   dir.create(p, FALSE, TRUE)
   dir.create(file.path(p, "src"))
-  files <- c("DESCRIPTION", "NAMESPACE", "src/Makevars", "src/dust.cpp")
+  dir.create(file.path(p, "R"))
+  files <- c("DESCRIPTION", "NAMESPACE",
+             "src/Makevars", "src/dust.cpp", "src/cpp11.cpp",
+             "R/dust.R", "R/cpp11.R")
   for (f in files) {
     file.create(file.path(p, f))
   }


### PR DESCRIPTION
This PR lets dust use a directory that contains more of its files.

Fixes #56 
