### PR TITLE
i58: rng state

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dust
 Title: Iterate Multiple Realisations of Stochastic Models
-Version: 0.2.1
+Version: 0.2.2
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("John", "Lees", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+# dust 0.2.2
+
+* New `$rng_state()` method for getting the RNG state as a raw vector
+
+# dust 0.2.0
+
+* Use cpp11 as the backend (#22)
+
 # dust 0.1.5
 
 * Simpler RNG interface; we now always use as many RNG streams as there are particles (#51)

--- a/R/cpp11.R
+++ b/R/cpp11.R
@@ -40,6 +40,10 @@ dust_rng_rpois <- function(ptr, n, lambda) {
   .Call("_dust_dust_rng_rpois", ptr, n, lambda)
 }
 
+dust_rng_state <- function(ptr) {
+  .Call("_dust_dust_rng_state", ptr)
+}
+
 cpp_openmp_info <- function() {
   .Call("_dust_cpp_openmp_info")
 }

--- a/R/dust_class.R
+++ b/R/dust_class.R
@@ -123,7 +123,10 @@ dust_class <- R6::R6Class(
     },
 
     ##' @description
-    ##' Returns the state of the random number generator
+    ##' Returns the state of the random number generator. This returns a
+    ##' raw vector of length 32 * n_particles. It is primarily intended for
+    ##' debugging as one cannot (yet) initialise a dust object with this
+    ##' state.
     rng_state = function() {
     }
   ))

--- a/R/dust_class.R
+++ b/R/dust_class.R
@@ -120,5 +120,10 @@ dust_class <- R6::R6Class(
     ##' Only returns non-NULL if the model provides a `dust_info` template
     ##' specialisation.
     info = function() {
+    },
+
+    ##' @description
+    ##' Returns the state of the random number generator
+    rng_state = function() {
     }
   ))

--- a/R/rng.R
+++ b/R/rng.R
@@ -122,7 +122,11 @@ dust_rng <- R6::R6Class(
       dust_rng_rpois(private$ptr, n, recycle(lambda, n))
     },
 
-    ##' Dump the rng state
+    ##' @description
+    ##' Returns the state of the random number generator. This returns a
+    ##' raw vector of length 32 * n_generators. It is primarily intended for
+    ##' debugging as one cannot (yet) initialise a dust_rng object with this
+    ##' state.
     state = function() {
       dust_rng_state(private$ptr)
     }

--- a/R/rng.R
+++ b/R/rng.R
@@ -120,6 +120,11 @@ dust_rng <- R6::R6Class(
     ##' @param lambda The mean (zero or more, length 1 or n)
     rpois = function(n, lambda) {
       dust_rng_rpois(private$ptr, n, recycle(lambda, n))
+    },
+
+    ##' Dump the rng state
+    state = function() {
+      dust_rng_state(private$ptr)
     }
   ))
 

--- a/inst/include/dust/dust.hpp
+++ b/inst/include/dust/dust.hpp
@@ -205,6 +205,10 @@ public:
     return _particles.front().step();
   }
 
+  std::vector<uint64_t> rng_state() {
+    return _rng.get_state();
+  }
+
 private:
   std::vector<size_t> _index;
   const size_t _n_threads;

--- a/inst/include/dust/interface.hpp
+++ b/inst/include/dust/interface.hpp
@@ -3,6 +3,7 @@
 #include <cpp11/integers.hpp>
 #include <cpp11/list.hpp>
 #include <cpp11/matrix.hpp>
+#include <cpp11/raws.hpp>
 #include <cpp11/strings.hpp>
 
 template <typename T>
@@ -187,6 +188,16 @@ void dust_reorder(SEXP ptr, cpp11::sexp r_index) {
   }
 
   obj->reorder(index);
+}
+
+template <typename T>
+SEXP dust_rng_state(SEXP ptr) {
+  Dust<T> *obj = cpp11::as_cpp<cpp11::external_pointer<Dust<T>>>(ptr).get();
+  auto state = obj->rng_state();
+  size_t len = sizeof(uint64_t) * state.size();
+  cpp11::writable::raws ret(len);
+  memcpy(RAW(ret), state.data(), len);
+  return ret;
 }
 
 // Trivial default implementation of a method for getting back

--- a/inst/include/dust/interface.hpp
+++ b/inst/include/dust/interface.hpp
@@ -1,3 +1,4 @@
+#include <cstring>
 #include <cpp11/doubles.hpp>
 #include <cpp11/external_pointer.hpp>
 #include <cpp11/integers.hpp>
@@ -196,7 +197,7 @@ SEXP dust_rng_state(SEXP ptr) {
   auto state = obj->rng_state();
   size_t len = sizeof(uint64_t) * state.size();
   cpp11::writable::raws ret(len);
-  memcpy(RAW(ret), state.data(), len);
+  std::memcpy(RAW(ret), state.data(), len);
   return ret;
 }
 

--- a/inst/include/dust/rng.hpp
+++ b/inst/include/dust/rng.hpp
@@ -48,6 +48,10 @@ public:
     _generator.long_jump();
   }
 
+  void get_state(std::vector<uint64_t>& state) {
+    _generator.get_state(state);
+  }
+
 private:
   dust::Xoshiro<real_t> _generator;
 };
@@ -86,6 +90,15 @@ public:
     for (size_t i = 0; i < _rngs.size(); ++i) {
       _rngs[i].long_jump();
     }
+  }
+
+  std::vector<uint64_t> get_state() {
+    std::vector<uint64_t> state;
+    //state.reserve(size() * XOSHIRO_WIDTH);
+    for (size_t i = 0; i < size(); ++i) {
+      _rngs[i].get_state(state);
+    }
+    return state;
   }
 
 private:

--- a/inst/include/dust/xoshiro.hpp
+++ b/inst/include/dust/xoshiro.hpp
@@ -42,6 +42,8 @@ public:
   void jump();
   void long_jump();
 
+  void get_state(std::vector<uint64_t>& state);
+
 private:
   static uint64_t splitmix64(uint64_t seed);
   uint64_t _state[XOSHIRO_WIDTH];
@@ -152,6 +154,13 @@ inline void Xoshiro<T>::long_jump() {
   _state[1] = s1;
   _state[2] = s2;
   _state[3] = s3;
+}
+
+template <typename T>
+inline void Xoshiro<T>::get_state(std::vector<uint64_t>& state) {
+  for (size_t i = 0; i < XOSHIRO_WIDTH; ++i) {
+    state.push_back(_state[i]);
+  }
 }
 
 }

--- a/inst/template/dust.R.template
+++ b/inst/template/dust.R.template
@@ -128,7 +128,10 @@
     },
 
     ##' @description
-    ##' Returns the state of the random number generator
+    ##' Returns the state of the random number generator. This returns a
+    ##' raw vector of length 32 * n_particles. It is primarily intended for
+    ##' debugging as one cannot (yet) initialise a dust object with this
+    ##' state.
     rng_state = function() {
       dust_{{name}}_rng_state(private$ptr)
     }

--- a/inst/template/dust.R.template
+++ b/inst/template/dust.R.template
@@ -125,5 +125,11 @@
     ##' specialisation.
     info = function() {
       private$data
+    },
+
+    ##' @description
+    ##' Returns the state of the random number generator
+    rng_state = function() {
+      dust_{{name}}_rng_state(private$ptr)
     }
   ))

--- a/inst/template/dust.cpp
+++ b/inst/template/dust.cpp
@@ -46,3 +46,8 @@ size_t dust_{{name}}_step(SEXP ptr) {
 void dust_{{name}}_reorder(SEXP ptr, cpp11::sexp r_index) {
   return dust_reorder<{{type}}>(ptr, r_index);
 }
+
+[[cpp11::register]]
+SEXP dust_{{name}}_rng_state(SEXP ptr) {
+  return dust_rng_state<{{type}}>(ptr);
+}

--- a/man/dust.Rd
+++ b/man/dust.Rd
@@ -149,6 +149,7 @@ obj$state()
 \item \href{#method-step}{\code{dust_class$step()}}
 \item \href{#method-reorder}{\code{dust_class$reorder()}}
 \item \href{#method-info}{\code{dust_class$info()}}
+\item \href{#method-rng_state}{\code{dust_class$rng_state()}}
 }
 }
 \if{html}{\out{<hr>}}
@@ -339,6 +340,16 @@ Only returns non-NULL if the model provides a \code{dust_info} template
 specialisation.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{dust_class$info()}\if{html}{\out{</div>}}
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-rng_state"></a>}}
+\if{latex}{\out{\hypertarget{method-rng_state}{}}}
+\subsection{Method \code{rng_state()}}{
+Returns the state of the random number generator
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{dust_class$rng_state()}\if{html}{\out{</div>}}
 }
 
 }

--- a/man/dust.Rd
+++ b/man/dust.Rd
@@ -347,7 +347,10 @@ specialisation.
 \if{html}{\out{<a id="method-rng_state"></a>}}
 \if{latex}{\out{\hypertarget{method-rng_state}{}}}
 \subsection{Method \code{rng_state()}}{
-Returns the state of the random number generator
+Returns the state of the random number generator. This returns a
+raw vector of length 32 * n_particles. It is primarily intended for
+debugging as one cannot (yet) initialise a dust object with this
+state.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{dust_class$rng_state()}\if{html}{\out{</div>}}
 }

--- a/man/dust_rng.Rd
+++ b/man/dust_rng.Rd
@@ -210,8 +210,7 @@ Generate \code{n} numbers from a Poisson distribution}
 \describe{
 \item{\code{n}}{Number of samples to draw}
 
-\item{\code{lambda}}{The mean (zero or more, length 1 or n)
-Dump the rng state}
+\item{\code{lambda}}{The mean (zero or more, length 1 or n)}
 }
 \if{html}{\out{</div>}}
 }
@@ -220,6 +219,10 @@ Dump the rng state}
 \if{html}{\out{<a id="method-state"></a>}}
 \if{latex}{\out{\hypertarget{method-state}{}}}
 \subsection{Method \code{state()}}{
+Returns the state of the random number generator. This returns a
+raw vector of length 32 * n_generators. It is primarily intended for
+debugging as one cannot (yet) initialise a dust_rng object with this
+state.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{dust_rng$state()}\if{html}{\out{</div>}}
 }

--- a/man/dust_rng.Rd
+++ b/man/dust_rng.Rd
@@ -42,6 +42,7 @@ rng$rpois(5, 2)
 \item \href{#method-rnorm}{\code{dust_rng$rnorm()}}
 \item \href{#method-rbinom}{\code{dust_rng$rbinom()}}
 \item \href{#method-rpois}{\code{dust_rng$rpois()}}
+\item \href{#method-state}{\code{dust_rng$state()}}
 }
 }
 \if{html}{\out{<hr>}}
@@ -209,9 +210,19 @@ Generate \code{n} numbers from a Poisson distribution}
 \describe{
 \item{\code{n}}{Number of samples to draw}
 
-\item{\code{lambda}}{The mean (zero or more, length 1 or n)}
+\item{\code{lambda}}{The mean (zero or more, length 1 or n)
+Dump the rng state}
 }
 \if{html}{\out{</div>}}
 }
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-state"></a>}}
+\if{latex}{\out{\hypertarget{method-state}{}}}
+\subsection{Method \code{state()}}{
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{dust_rng$state()}\if{html}{\out{</div>}}
+}
+
 }
 }

--- a/src/cpp11.cpp
+++ b/src/cpp11.cpp
@@ -75,6 +75,13 @@ extern "C" SEXP _dust_dust_rng_rpois(SEXP ptr, SEXP n, SEXP lambda) {
     return cpp11::as_sexp(dust_rng_rpois(cpp11::unmove(cpp11::as_cpp<SEXP>(ptr)), cpp11::unmove(cpp11::as_cpp<int>(n)), cpp11::unmove(cpp11::as_cpp<std::vector<double>>(lambda))));
   END_CPP11
 }
+// dust_rng.cpp
+cpp11::writable::raws dust_rng_state(SEXP ptr);
+extern "C" SEXP _dust_dust_rng_state(SEXP ptr) {
+  BEGIN_CPP11
+    return cpp11::as_sexp(dust_rng_state(cpp11::unmove(cpp11::as_cpp<SEXP>(ptr))));
+  END_CPP11
+}
 // openmp.cpp
 cpp11::writable::list cpp_openmp_info();
 extern "C" SEXP _dust_cpp_openmp_info() {
@@ -95,6 +102,7 @@ extern SEXP _dust_dust_rng_rnorm(SEXP, SEXP, SEXP, SEXP);
 extern SEXP _dust_dust_rng_rpois(SEXP, SEXP, SEXP);
 extern SEXP _dust_dust_rng_runif(SEXP, SEXP, SEXP, SEXP);
 extern SEXP _dust_dust_rng_size(SEXP);
+extern SEXP _dust_dust_rng_state(SEXP);
 extern SEXP _dust_dust_rng_unif_rand(SEXP, SEXP);
 
 static const R_CallMethodDef CallEntries[] = {
@@ -108,6 +116,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_dust_dust_rng_rpois",     (DL_FUNC) &_dust_dust_rng_rpois,     3},
     {"_dust_dust_rng_runif",     (DL_FUNC) &_dust_dust_rng_runif,     4},
     {"_dust_dust_rng_size",      (DL_FUNC) &_dust_dust_rng_size,      1},
+    {"_dust_dust_rng_state",     (DL_FUNC) &_dust_dust_rng_state,     1},
     {"_dust_dust_rng_unif_rand", (DL_FUNC) &_dust_dust_rng_unif_rand, 2},
     {NULL, NULL, 0}
 };

--- a/src/dust_rng.cpp
+++ b/src/dust_rng.cpp
@@ -1,4 +1,5 @@
 #include <cpp11/external_pointer.hpp>
+#include <cpp11/raws.hpp>
 #include <dust/rng.hpp>
 
 typedef dust::pRNG<double, int> dust_rng_t;
@@ -96,4 +97,15 @@ std::vector<int>  dust_rng_rpois(SEXP ptr, int n,
     y[i] = rng->get(i % n_generators).rpois(lambda[i]);
   }
   return y;
+}
+
+
+[[cpp11::register]]
+cpp11::writable::raws dust_rng_state(SEXP ptr) {
+  dust_rng_t *rng = cpp11::as_cpp<dust_rng_ptr_t>(ptr).get();
+  auto state = rng->get_state();
+  size_t len = sizeof(uint64_t) * state.size();
+  cpp11::writable::raws ret(len);
+  memcpy(RAW(ret), state.data(), len);
+  return ret;
 }

--- a/src/dust_rng.cpp
+++ b/src/dust_rng.cpp
@@ -1,3 +1,4 @@
+#include <cstring>
 #include <cpp11/external_pointer.hpp>
 #include <cpp11/raws.hpp>
 #include <dust/rng.hpp>
@@ -106,6 +107,6 @@ cpp11::writable::raws dust_rng_state(SEXP ptr) {
   auto state = rng->get_state();
   size_t len = sizeof(uint64_t) * state.size();
   cpp11::writable::raws ret(len);
-  memcpy(RAW(ret), state.data(), len);
+  std::memcpy(RAW(ret), state.data(), len);
   return ret;
 }

--- a/tests/testthat/test-interface.R
+++ b/tests/testthat/test-interface.R
@@ -136,3 +136,15 @@ test_that("validate package interface", {
                      formals(cmp$public_methods[[m]]))
   }
 })
+
+
+test_that("get rng state", {
+  seed <- 1
+  np <- 10
+  res <- compile_and_load(dust_file("examples/walk.cpp"), "walk", "mywalk",
+                          quiet = TRUE)
+  obj <- res$new(list(sd = 1), 0L, np, seed = seed)
+  expect_identical(
+    obj$rng_state(),
+    dust_rng$new(seed, np)$state())
+})

--- a/tests/testthat/test-rng.R
+++ b/tests/testthat/test-rng.R
@@ -224,3 +224,23 @@ test_that("long jump", {
   expect_true(all(r2 != r4))
   expect_true(all(r3 != r4))
 })
+
+
+test_that("get state", {
+  seed <- 1
+  rng1 <- dust_rng$new(seed, 1L)
+  rng2 <- dust_rng$new(seed, 1L)
+  rng3 <- dust_rng$new(seed, 2L)
+
+  s1 <- rng1$state()
+  expect_type(s1, "raw")
+  expect_equal(length(s1), 32)
+
+  s2 <- rng2$state()
+  expect_identical(s2, s1)
+
+  s3 <- rng3$state()
+  expect_equal(length(s3), 64)
+  expect_identical(s3[seq_len(32)], s1)
+  expect_identical(s3[-seq_len(32)], rng2$jump()$state())
+})


### PR DESCRIPTION
This PR adds a method `state` to the rng object and `rng_state` to the dust object, for retrieving the RNG state. Little useful can be done with these but they might be helpful for debugging.

Fixes #58 