### PR TITLE
Fix argument order in deleter

### DIFF
--- a/inst/include/dust/interface.hpp
+++ b/inst/include/dust/interface.hpp
@@ -34,7 +34,7 @@ cpp11::list dust_alloc(cpp11::list r_data, int step,
   typename T::init_t data = dust_data<T>(r_data);
 
   Dust<T> *d = new Dust<T>(data, step, n_particles, n_threads, seed);
-  cpp11::external_pointer<Dust<T>> ptr(d, false, true);
+  cpp11::external_pointer<Dust<T>> ptr(d, true, false);
   cpp11::sexp info = dust_info<T>(data);
 
   return cpp11::writable::list({ptr, info});


### PR DESCRIPTION
See https://github.com/r-lib/cpp11/blob/dbddd7b4d4defec12df23b70dfcef070cd308fe8/inst/include/cpp11/external_pointer.hpp#L53

Not easy to test, except that the application leaks

Fixes #61 