### PR TITLE
i63: fix and test docker build

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -17,3 +17,4 @@
 \.gcno$
 ^pkgdown$
 ^LICENSE\.md$
+^buildkite$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,8 @@ Imports:
     R6,
     cpp11,
     glue,
-    pkgbuild
+    pkgbuild,
+    withr
 LinkingTo:
     cpp11
 Suggests:
@@ -31,8 +32,7 @@ Suggests:
     mockery,
     pkgload,
     rmarkdown,
-    testthat,
-    withr
+    testthat
 RoxygenNote: 7.1.0
 Roxygen: list(markdown = TRUE)
 VignetteBuilder: knitr

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dust
 Title: Iterate Multiple Realisations of Stochastic Models
-Version: 0.2.2
+Version: 0.2.3
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("John", "Lees", role = "aut"),

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Project Status: WIP – Initial development is in progress, but there has not yet been a stable, usable release suitable for the public.](https://www.repostatus.org/badges/latest/wip.svg)](https://www.repostatus.org/#wip)
 [![Build Status](https://travis-ci.com/mrc-ide/dust.svg?branch=master)](https://travis-ci.com/mrc-ide/dust)
 [![AppVeyor build status](https://ci.appveyor.com/api/projects/status/github/mrc-ide/dust?branch=master&svg=true)](https://ci.appveyor.com/project/mrc-ide/dust)
+[![Build status](https://badge.buildkite.com/bf7030c393da3ab92f65c63de87bb301b9657a8a9ac6dfb981.svg)](https://buildkite.com/mrc-ide/dust)
 [![CodeFactor](https://www.codefactor.io/repository/github/mrc-ide/dust/badge)](https://www.codefactor.io/repository/github/mrc-ide/dust)
 [![codecov.io](https://codecov.io/github/mrc-ide/dust/coverage.svg?branch=master)](https://codecov.io/github/mrc-ide/dust?branch=master)
 <!-- badges: end -->

--- a/buildkite/pipeline.yml
+++ b/buildkite/pipeline.yml
@@ -1,0 +1,8 @@
+steps:
+  - label: ":whale::rstats: Build"
+    command: docker/build
+
+  - wait
+
+  - label: ":shipit: Push images"
+    command: docker/push

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -24,3 +24,5 @@ RUN install2.r --error \
         remotes \
         roxygen2 \
         testthat
+
+RUN R CMD INSTALL .

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,6 +9,9 @@ RUN apt-get update &&  apt-get install -y --no-install-recommends \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
+# Without this, we are unable to pick up more recent packages
+COPY Rprofile.site /usr/local/lib/R/etc/Rprofile.site
+
 RUN install2.r --error \
         R6 \
         brio \
@@ -20,7 +23,3 @@ RUN install2.r --error \
         remotes \
         roxygen2 \
         testthat
-
-RUN installGithub.r \
-        r-lib/cpp11 \
-        r-lib/pkgbuild@cpp11

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,6 +16,7 @@ RUN install2.r --error \
         R6 \
         bench \
         brio \
+        cpp11 \
         decor \
         devtools \
         glue \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update &&  apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Without this, we are unable to pick up more recent packages
-COPY Rprofile.site /usr/local/lib/R/etc/Rprofile.site
+COPY docker/Rprofile.site /usr/local/lib/R/etc/Rprofile.site
 
 RUN install2.r --error \
         R6 \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -25,4 +25,5 @@ RUN install2.r --error \
         roxygen2 \
         testthat
 
-RUN R CMD INSTALL .
+COPY . /src
+RUN R CMD INSTALL /src && rm -rf /src

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,6 +14,7 @@ COPY docker/Rprofile.site /usr/local/lib/R/etc/Rprofile.site
 
 RUN install2.r --error \
         R6 \
+        bench \
         brio \
         decor \
         devtools \

--- a/docker/Rprofile.site
+++ b/docker/Rprofile.site
@@ -1,0 +1,4 @@
+options(repos = c(CRAN = 'https://packagemanager.rstudio.com/all/__linux__/focal/latest'), download.file.method = 'libcurl')
+options(HTTPUserAgent = sprintf("R/%s R (%s)", getRversion(),
+                 paste(getRversion(), R.version$platform,
+                       R.version$arch, R.version$os)))

--- a/docker/build
+++ b/docker/build
@@ -1,4 +1,13 @@
 #!/usr/bin/env bash
-set -e
+set -ex
 HERE=$(dirname $0)
-docker build -t mrcide/dust $HERE
+. $HERE/common
+
+docker build --pull \
+       --tag $TAG_SHA \
+       -f docker/Dockerfile \
+       .
+
+# We always push the SHA tagged versions, for debugging if the tests
+# after this step fail
+docker push $TAG_SHA

--- a/docker/common
+++ b/docker/common
@@ -1,0 +1,29 @@
+# -*-sh-*-
+PACKAGE_ROOT=$(realpath $HERE/..)
+PACKAGE_NAME=dust
+PACKAGE_ORG=mrcide
+PACKAGE_VERSION=$(cat $PACKAGE_ROOT/DESCRIPTION | \
+                      grep '^Version:' | sed 's/^.*: *//')
+
+# Buildkite doesn't check out a full history from the remote (just the
+# single commit) so you end up with a detached head and git rev-parse
+# doesn't work
+if [ "$BUILDKITE" = "true" ]; then
+    GIT_SHA=${BUILDKITE_COMMIT:0:7}
+else
+    GIT_SHA=$(git -C "$PACKAGE_ROOT" rev-parse --short=7 HEAD)
+fi
+
+
+if [ "$TRAVIS" = "true" ]; then
+    GIT_BRANCH=$TRAVIS_BRANCH
+elif [ "$BUILDKITE" = "true" ]; then
+    GIT_BRANCH=$BUILDKITE_BRANCH
+else
+    GIT_BRANCH=$(git -C "$PACKAGE_ROOT" symbolic-ref --short HEAD)
+fi
+
+TAG_SHA="${PACKAGE_ORG}/${PACKAGE_NAME}:${GIT_SHA}"
+TAG_BRANCH="${PACKAGE_ORG}/${PACKAGE_NAME}:${GIT_BRANCH}"
+TAG_VERSION="${PACKAGE_ORG}/${PACKAGE_NAME}:v${PACKAGE_VERSION}"
+TAG_LATEST="${PACKAGE_ORG}/${PACKAGE_NAME}:latest"

--- a/docker/push
+++ b/docker/push
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -e
+HERE=$(dirname $0)
+. $HERE/common
+
+# In case we switch agents between steps
+[ ! -z $(docker images -q $TAG_SHA) ] || docker pull $TAG_SHA
+
+docker tag $TAG_SHA $TAG_BRANCH
+docker push $TAG_BRANCH
+
+if [ $GIT_BRANCH == "master" ]; then
+   docker tag $TAG_SHA $TAG_LATEST
+   docker tag $TAG_SHA $TAG_VERSION
+   docker push $TAG_LATEST
+   docker push $TAG_VERSION
+fi

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -55,3 +55,63 @@ test_that("assert_is", {
   expect_error(assert_is(thing, c("x", "y")),
                "'thing' must be a x / y")
 })
+
+
+test_that("Can avoid debug in compile_dll", {
+  skip_if_not_installed("mockery")
+
+  mock_has_user_makevars <- mockery::mock(FALSE)
+  mock_compile_dll <- mockery::mock(
+    list(Sys.getenv("R_MAKEVARS_USER"), pkgbuild:::makevars_user()))
+
+  path <- tempfile()
+  compile_attributes <- TRUE
+  quiet <- FALSE
+  res <- with_mock(
+    "dust::has_user_makevars" = mock_has_user_makevars,
+    "pkgbuild::compile_dll" = mock_compile_dll,
+    compile_dll(path, compile_attributes, quiet))
+
+  expect_equal(res[[1]], res[[2]])
+  expect_equal(dirname(res[[1]]), tempdir())
+
+  mockery::expect_called(mock_has_user_makevars, 1)
+  mockery::expect_called(mock_compile_dll, 1)
+  expect_equal(
+    mockery::mock_args(mock_compile_dll)[[1]],
+    list(path, compile_attributes, quiet))
+})
+
+
+test_that("Don't set envvar if not needed", {
+  skip_if_not_installed("mockery")
+
+  env <- c("R_MAKEVARS_USER" = NA)
+  cmp <- withr::with_envvar(
+    env,
+    pkgbuild:::makevars_user())
+
+  mock_has_user_makevars <- mockery::mock(TRUE)
+  mock_compile_dll <- mockery::mock(
+    list(Sys.getenv("R_MAKEVARS_USER"), pkgbuild:::makevars_user()))
+
+  path <- tempfile()
+  compile_attributes <- TRUE
+  quiet <- FALSE
+
+  res <- withr::with_envvar(
+    env,
+    with_mock(
+      "dust::has_user_makevars" = mock_has_user_makevars,
+      "pkgbuild::compile_dll" = mock_compile_dll,
+      compile_dll(path, compile_attributes, quiet)))
+
+  expect_equal(res[[1]], "")
+  expect_equal(res[[2]], cmp)
+
+  mockery::expect_called(mock_has_user_makevars, 1)
+  mockery::expect_called(mock_compile_dll, 1)
+  expect_equal(
+    mockery::mock_args(mock_compile_dll)[[1]],
+    list(path, compile_attributes, quiet))
+})

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -73,7 +73,8 @@ test_that("Can avoid debug in compile_dll", {
     compile_dll(path, compile_attributes, quiet))
 
   expect_equal(res[[1]], res[[2]])
-  expect_equal(dirname(res[[1]]), tempdir())
+  expect_equal(normalizePath(dirname(res[[1]])),
+               normalizePath(tempdir()))
 
   mockery::expect_called(mock_has_user_makevars, 1)
   mockery::expect_called(mock_compile_dll, 1)


### PR DESCRIPTION
This PR fixes the docker build; as the R version changed and dependencies made it onto CRAN, the docker image no longer built due to rocker's version pinning.  Here, I've added the same Rprofile.site that we use in orderly that disables this pinning. I've also set up builds on buildkite that do a build and push

Fixes #63 