### PR TITLE
Add profiler start/stop

### DIFF
--- a/inst/include/dust/gpu/dust.hpp
+++ b/inst/include/dust/gpu/dust.hpp
@@ -216,6 +216,7 @@ public:
     _particle_y_addrs(nullptr),
     _particle_y_swap_addrs(nullptr) {
     initialise(data, step, n_particles);
+    cudaProfilerStart();
     cudaDeviceSynchronize();
   }
 
@@ -224,6 +225,7 @@ public:
     CUDA_CALL(cudaFree(_model_addrs));
     CUDA_CALL(cudaFree(_particle_y_addrs));
     CUDA_CALL(cudaFree(_particle_y_swap_addrs));
+    cudaProfilerStop();
   }
 
   void reset(const init_t data, const size_t step) {


### PR DESCRIPTION
Allows better profiler targeting when running `nsys profile -o timeline_100k_sirs --trace cuda,nvtx,osrt,openacc -c cudaProfilerStart Rscript timeline.R`