### PR TITLE
Transfer index names onto extracted data

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dust
 Title: Iterate Multiple Realisations of Stochastic Models
-Version: 0.4.2
+Version: 0.4.3
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("John", "Lees", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# dust 0.4.3
+
+* If `$set_index()` uses a named index vector, then those names are copied back as rownames on the returned matrix. Similarly, if `$state()` is used with a named index then those names are used as rownames (#81)
+
 # dust 0.4.0
 
 * Can now generate dust objects that run on the GPU (#69)

--- a/inst/template/dust.R.template
+++ b/inst/template/dust.R.template
@@ -4,6 +4,7 @@
 
   private = list(
     data = NULL,
+    index_names = NULL,
     ptr = NULL
   ),
 
@@ -47,9 +48,11 @@
     ##' at that point.
     ##'
     ##' @param step_end Step to run to (if less than or equal to the current
-    ##' step(),silently nothing will happen)
+    ##' step(), silently nothing will happen)
     run = function(step_end) {
-      dust_{{name}}_run(private$ptr, step_end)
+      m <- dust_{{name}}_run(private$ptr, step_end)
+      rownames(m) <- private$index_names
+      m
     },
 
     ##' @description
@@ -65,6 +68,8 @@
     ##' validated, and an error thrown if an invalid index is given).
     set_index = function(index) {
       dust_{{name}}_set_index(private$ptr, index)
+      private$index_names <- index_names(index)
+      invisible()
     },
 
     ##' @description
@@ -93,6 +98,7 @@
     ##' @param step New initial step for the model (see constructor)
     reset = function(data, step) {
       private$data <- dust_{{name}}_reset(private$ptr, data, step)
+      private$index_names <- NULL
       invisible()
     },
 
@@ -100,7 +106,9 @@
     ##' Return full model state
     ##' @param index Optional index to select state using
     state = function(index = NULL) {
-      dust_{{name}}_state(private$ptr, index)
+      m <- dust_{{name}}_state(private$ptr, index)
+      rownames(m) <- names(index)
+      m
     },
 
     ##' @description

--- a/inst/template/dust.R.template
+++ b/inst/template/dust.R.template
@@ -68,7 +68,7 @@
     ##' validated, and an error thrown if an invalid index is given).
     set_index = function(index) {
       dust_{{name}}_set_index(private$ptr, index)
-      private$index_names <- index_names(index)
+      private$index_names <- names(index)
       invisible()
     },
 

--- a/tests/testthat/test-interface.R
+++ b/tests/testthat/test-interface.R
@@ -148,3 +148,53 @@ test_that("get rng state", {
     obj$rng_state(),
     dust_rng$new(seed, np)$state())
 })
+
+
+test_that("setting a named index returns names", {
+  res <- dust(dust_file("examples/sirs.cpp"), quiet = TRUE)
+  mod <- res$new(list(), 0, 10)
+
+  mod$set_index(3:1)
+  expect_identical(
+    mod$run(0),
+    rbind(rep(0, 10), rep(10, 10), rep(1000, 10)))
+
+  mod$set_index(c(S = 1L, I = 2L, R = 3L))
+  expect_identical(
+    mod$run(0),
+    rbind(S = rep(1000, 10), I = rep(10, 10), R = rep(0, 10)))
+
+  mod$set_index(seq_len(3))
+  expect_identical(
+    mod$run(0),
+    rbind(rep(1000, 10), rep(10, 10), rep(0, 10)))
+
+})
+
+
+test_that("resetting removes index names", {
+  res <- dust(dust_file("examples/variable.cpp"), quiet = TRUE)
+  mod <- res$new(list(len = 10), 0, 5)
+
+  mod$set_index(setNames(1:3, c("x", "y", "z")))
+  expect_equal(
+    mod$run(0),
+    matrix(1:3, 3, 5, dimnames = list(c("x", "y", "z"), NULL)))
+
+  mod$reset(list(len = 2), 0)
+  expect_equal(
+    mod$run(0),
+    matrix(1:2, 2, 5))
+})
+
+
+test_that("names are copied when using state()", {
+  res <- dust(dust_file("examples/variable.cpp"), quiet = TRUE)
+  mod <- res$new(list(len = 10), 0, 5)
+  expect_equal(
+    mod$state(4:5),
+    matrix(4:5, 2, 5))
+  expect_equal(
+    mod$state(c(x = 4L, y = 5L)),
+    matrix(4:5, 2, 5, dimnames = list(c("x", "y"), NULL)))
+})

--- a/vignettes/dust.Rmd
+++ b/vignettes/dust.Rmd
@@ -189,6 +189,13 @@ model$run(20)
 
 This is useful when you have many compartments or variables that you are not that interested in during running the model. For a particle filter you might be fitting to the sum of all infected individuals over a number of compartments, so rather than returning hundreds of values back (times hundreds of particles) you can return back much less data and keep things nice and fast.
 
+If the index vector is named, then those names will be used as row names on the returned object:
+
+```{r sir_run_named}
+model$set_index(c(I = 2L))
+model$run(30)
+```
+
 We can always use `$state()` to get the whole state vector:
 
 ```{r sir_state}
@@ -198,8 +205,10 @@ model$state()
 or select only variables of interest:
 
 ```{r sir_state_select}
-model$state(c(1L, 3L))
+model$state(c(S = 1L, R = 3L))
 ```
+
+Again, this copies names from the index if they are present.
 
 In order to run the simulation beginning-to-end, we use `dust::dust_simulate()`; this function is purely a convenience function and the intention is that you would write your own (see [`mcstate`](https://mrc-ide.github.io/mcstate) for example).
 


### PR DESCRIPTION
Works for both run (via set_index) and state (via the index argument). The data is stored in the R6 class as "index_names" as that's slightly easier than keeping a copy of the R object or doing a conversion between something like `std::vector<std::string>` on every run. We can move it into the C++ code later if we want though.

Fixes #81 