### PR TITLE
i101: Copy rownames from index to output in iterate

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dust
 Title: Iterate Multiple Realisations of Stochastic Models
-Version: 0.4.10
+Version: 0.4.11
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("John", "Lees", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# dust 0.4.11
+
+* `dust::dust_iterate` now copies names from the index as rownames (#101)
+
 # dust 0.4.9
 
 * The "low `n * p`" branch of the binomial distribution now uses a slightly faster algorithm (#91)

--- a/R/iterate.R
+++ b/R/iterate.R
@@ -52,5 +52,6 @@ dust_iterate <- function(model, steps, index = NULL) {
     model$run(steps[[i]])
     res[, , i] <- model$state(index)
   }
+  rownames(res) <- names(index)
   res
 }

--- a/tests/testthat/test-iterate.R
+++ b/tests/testthat/test-iterate.R
@@ -41,3 +41,16 @@ test_that("validate start time", {
   expect_error(dust_iterate(obj, 10:100),
                "Expected first 'steps' element to be 4")
 })
+
+
+test_that("Set names if provided", {
+  res <- dust_example("sir")
+
+  m1 <- dust_iterate(res$new(list(), 0, 100, seed = 1L), 0:100,
+                     1:3)
+  m2 <- dust_iterate(res$new(list(), 0, 100, seed = 1L), 0:100,
+                     c(S = 1L, I = 2L, R = 3L))
+
+  expect_equal(unname(m1), unname(m2))
+  expect_equal(rownames(m2), c("S", "I", "R"))
+})


### PR DESCRIPTION
This PR adds rownames to the output of `dust_iterate`, if the index used them. As noticed in sircovid work

Fixes #101 
