### PR TITLE
fix release

### DIFF
--- a/.github/workflows/make-release.yaml
+++ b/.github/workflows/make-release.yaml
@@ -2,7 +2,6 @@ on:
   push:
     branches:
       - master
-      - fix-release
 
 name: make-release
 

--- a/.github/workflows/make-release.yaml
+++ b/.github/workflows/make-release.yaml
@@ -2,6 +2,7 @@ on:
   push:
     branches:
       - master
+      - fix-release
 
 name: make-release
 
@@ -81,8 +82,8 @@ jobs:
 
       - name: Extract version
         run: |
-          echo "::set-env name=PACKAGE_VERSION::$(grep '^Version' DESCRIPTION  | sed 's/.*: *//')"
-          echo "::set-env name=PACKAGE_NAME::$(grep '^Package' DESCRIPTION  | sed 's/.*: *//')"
+          echo "PACKAGE_VERSION=$(grep '^Version' DESCRIPTION  | sed 's/.*: *//')" >> $GITHUB_ENV
+          echo "PACKAGE_NAME=$(grep '^Package' DESCRIPTION  | sed 's/.*: *//')" >> $GITHUB_ENV
 
       - uses: actions/download-artifact@v2
         with:
@@ -110,8 +111,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: pkg/pkg-macOS-latest-release/${{ env.PACKAGE_NAME }}_${{ env.PACKAGE_VERSION }}.tgz
-          asset_name: ${{ env.PACKAGE_NAME }}_${{ env.PACKAGE_VERSION }}.tgz
+          asset_path: pkg/pkg-macOS-latest-release/${{ env.PACKAGE_NAME }}_${{ env.PACKAGE_VERSION }}.tar.gz
+          asset_name: ${{ env.PACKAGE_NAME }}_${{ env.PACKAGE_VERSION }}.tar.gz
           asset_content_type: application/gzip
 
       - name: Upload macOS binary
@@ -120,8 +121,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: pkg/pkg-macOS-latest-release/${{ env.PACKAGE_NAME }}_${{ env.PACKAGE_VERSION }}.tar.gz
-          asset_name: ${{ env.PACKAGE_NAME }}_${{ env.PACKAGE_VERSION }}.tar.gz
+          asset_path: pkg/pkg-macOS-latest-release/${{ env.PACKAGE_NAME }}_${{ env.PACKAGE_VERSION }}.tgz
+          asset_name: ${{ env.PACKAGE_NAME }}_${{ env.PACKAGE_VERSION }}.tgz
           asset_content_type: application/gzip
 
       - name: Upload Windows binary
@@ -140,8 +141,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: pkg/pkg-macOS-latest-oldrel/${{ env.PACKAGE_NAME }}_${{ env.PACKAGE_VERSION }}.tar.gz
-          asset_name: ${{ env.PACKAGE_NAME }}_${{ env.PACKAGE_VERSION }}_oldrel.tar.gz
+          asset_path: pkg/pkg-macOS-latest-oldrel/${{ env.PACKAGE_NAME }}_${{ env.PACKAGE_VERSION }}.tgz
+          asset_name: ${{ env.PACKAGE_NAME }}_${{ env.PACKAGE_VERSION }}_oldrel.tgz
           asset_content_type: application/gzip
 
       - name: Upload Windows binary

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dust
 Title: Iterate Multiple Realisations of Stochastic Models
-Version: 0.5.4
+Version: 0.5.5
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("John", "Lees", role = "aut"),


### PR DESCRIPTION
Removes the deprecated github actions functionality following https://github.com/mrc-ide/sircovid/pull/164 and also now builds correct Mac binaries. Tested against this branch to create https://github.com/mrc-ide/dust/releases/tag/v0.5.4