### PR TITLE
New method to change the number of threads (#122)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dust
 Title: Iterate Multiple Realisations of Stochastic Models
-Version: 0.5.6
+Version: 0.5.7
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("John", "Lees", role = "aut"),

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,8 @@ website: pkgdown
 
 clean:
 	$(RM) src/*.o src/dust.so src/dust.dll \
-		tests/testthat/example/*.o tests/testthat/example/*.so
+		tests/testthat/example/*.o tests/testthat/example/*.so \
+		src/*.gcov src/*.gcda src/*.gcno
 
 vignettes: vignettes/dust.Rmd vignettes/rng.Rmd
 	${RSCRIPT} -e 'tools::buildVignettes(dir = ".")'

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# dust 0.5.7
+
+* New method `set_n_threads()` for changing the number of OpenMP threads after initialisation (#122)
+
 # dust 0.5.6
 
 * `dust::dust_simulate()` can return the entire model end state (#119)

--- a/R/cpp11.R
+++ b/R/cpp11.R
@@ -100,6 +100,10 @@ dust_sir_has_openmp <- function() {
   .Call("_dust_dust_sir_has_openmp", PACKAGE = "dust")
 }
 
+dust_sir_set_n_threads <- function(ptr, n_threads) {
+  invisible(.Call("_dust_dust_sir_set_n_threads", ptr, n_threads, PACKAGE = "dust"))
+}
+
 dust_variable_alloc <- function(r_data, step, n_particles, n_threads, r_seed) {
   .Call("_dust_dust_variable_alloc", r_data, step, n_particles, n_threads, r_seed, PACKAGE = "dust")
 }
@@ -150,6 +154,10 @@ dust_variable_simulate <- function(r_steps, r_data, r_state, r_index, n_threads,
 
 dust_variable_has_openmp <- function() {
   .Call("_dust_dust_variable_has_openmp", PACKAGE = "dust")
+}
+
+dust_variable_set_n_threads <- function(ptr, n_threads) {
+  invisible(.Call("_dust_dust_variable_set_n_threads", ptr, n_threads, PACKAGE = "dust"))
 }
 
 dust_volatility_alloc <- function(r_data, step, n_particles, n_threads, r_seed) {
@@ -204,6 +212,10 @@ dust_volatility_has_openmp <- function() {
   .Call("_dust_dust_volatility_has_openmp", PACKAGE = "dust")
 }
 
+dust_volatility_set_n_threads <- function(ptr, n_threads) {
+  invisible(.Call("_dust_dust_volatility_set_n_threads", ptr, n_threads, PACKAGE = "dust"))
+}
+
 dust_walk_alloc <- function(r_data, step, n_particles, n_threads, r_seed) {
   .Call("_dust_dust_walk_alloc", r_data, step, n_particles, n_threads, r_seed, PACKAGE = "dust")
 }
@@ -254,4 +266,8 @@ dust_walk_simulate <- function(r_steps, r_data, r_state, r_index, n_threads, r_s
 
 dust_walk_has_openmp <- function() {
   .Call("_dust_dust_walk_has_openmp", PACKAGE = "dust")
+}
+
+dust_walk_set_n_threads <- function(ptr, n_threads) {
+  invisible(.Call("_dust_dust_walk_set_n_threads", ptr, n_threads, PACKAGE = "dust"))
 }

--- a/R/dust.R
+++ b/R/dust.R
@@ -108,6 +108,13 @@ sir <- R6::R6Class(
 
     has_openmp = function() {
       dust_sir_has_openmp()
+    },
+
+    set_n_threads = function(n_threads) {
+      prev <- private$n_threads_
+      dust_sir_set_n_threads(private$ptr_, n_threads)
+      private$n_threads_ <- n_threads
+      invisible(prev)
     }
   ))
 class(sir) <- c("dust_generator", class(sir))
@@ -220,6 +227,13 @@ variable <- R6::R6Class(
 
     has_openmp = function() {
       dust_variable_has_openmp()
+    },
+
+    set_n_threads = function(n_threads) {
+      prev <- private$n_threads_
+      dust_variable_set_n_threads(private$ptr_, n_threads)
+      private$n_threads_ <- n_threads
+      invisible(prev)
     }
   ))
 class(variable) <- c("dust_generator", class(variable))
@@ -332,6 +346,13 @@ volatility <- R6::R6Class(
 
     has_openmp = function() {
       dust_volatility_has_openmp()
+    },
+
+    set_n_threads = function(n_threads) {
+      prev <- private$n_threads_
+      dust_volatility_set_n_threads(private$ptr_, n_threads)
+      private$n_threads_ <- n_threads
+      invisible(prev)
     }
   ))
 class(volatility) <- c("dust_generator", class(volatility))
@@ -444,6 +465,13 @@ walk <- R6::R6Class(
 
     has_openmp = function() {
       dust_walk_has_openmp()
+    },
+
+    set_n_threads = function(n_threads) {
+      prev <- private$n_threads_
+      dust_walk_set_n_threads(private$ptr_, n_threads)
+      private$n_threads_ <- n_threads
+      invisible(prev)
     }
   ))
 class(walk) <- c("dust_generator", class(walk))

--- a/R/dust_class.R
+++ b/R/dust_class.R
@@ -208,7 +208,10 @@ dust_class <- R6::R6Class(
     ##' model must be compiled with "OpenMP" support for this to have an
     ##' effect. Returns (invisibly) the previous value.
     ##'
-    ##' @param n_threads The new number of threads to use
+    ##' @param n_threads The new number of threads to use. You may want to
+    ##'   wrap this argument in [dust::dust_openmp_threads()] in order to
+    ##'   verify that you can actually use the number of threads
+    ##'   requested (based on environment variables and OpenMP support).
     set_n_threads = function(n_threads) {
     }
   ))

--- a/R/dust_class.R
+++ b/R/dust_class.R
@@ -201,6 +201,15 @@ dust_class <- R6::R6Class(
     ##' as a static method by running it directly
     ##' as `dust_class$public_methods$has_openmp()`
     has_openmp = function() {
+    },
+
+    ##' @description
+    ##' Change the number of threads that the dust object will use. Your
+    ##' model must be compiled with "OpenMP" support for this to have an
+    ##' effect. Returns (invisibly) the previous value.
+    ##'
+    ##' @param n_threads The new number of threads to use
+    set_n_threads = function(n_threads) {
     }
   ))
 class(dust_class) <- c("dust_generator", class(dust_class))

--- a/inst/include/dust/dust.hpp
+++ b/inst/include/dust/dust.hpp
@@ -255,6 +255,10 @@ public:
     _rng.import_state(rng_state);
   }
 
+  void set_n_threads(size_t n_threads) {
+    _n_threads = n_threads;
+  }
+
   // NOTE: it only makes sense to expose long_jump, and not jump,
   // because each rng stream is one jump away from the next.
   void rng_long_jump() {
@@ -263,7 +267,7 @@ public:
 
 private:
   std::vector<size_t> _index;
-  const size_t _n_threads;
+  size_t _n_threads;
   dust::pRNG<real_t> _rng;
   std::vector<Particle<T>> _particles;
 

--- a/inst/include/dust/interface.hpp
+++ b/inst/include/dust/interface.hpp
@@ -282,6 +282,13 @@ void dust_set_rng_state(SEXP ptr, cpp11::raws rng_state) {
   obj->set_rng_state(data);
 }
 
+template <typename T>
+void dust_set_n_threads(SEXP ptr, int n_threads) {
+  Dust<T> *obj = cpp11::as_cpp<cpp11::external_pointer<Dust<T>>>(ptr).get();
+  validate_positive(n_threads, "n_threads");
+  obj->set_n_threads(n_threads);
+}
+
 // Trivial default implementation of a method for getting back
 // arbitrary information from the object.
 template <typename T>

--- a/inst/template/dust.R.template
+++ b/inst/template/dust.R.template
@@ -228,6 +228,19 @@
     ##' as `{{name}}$public_methods$has_openmp()`
     has_openmp = function() {
       dust_{{name}}_has_openmp()
+    },
+
+    ##' @description
+    ##' Change the number of threads that the dust object will use. Your
+    ##' model must be compiled with "OpenMP" support for this to have an
+    ##' effect. Returns (invisibly) the previous value.
+    ##'
+    ##' @param n_threads The new number of threads to use
+    set_n_threads = function(n_threads) {
+      prev <- private$n_threads_
+      dust_{{name}}_set_n_threads(private$ptr_, n_threads)
+      private$n_threads_ <- n_threads
+      invisible(prev)
     }
   ))
 class({{name}}) <- c("dust_generator", class({{name}}))

--- a/inst/template/dust.R.template
+++ b/inst/template/dust.R.template
@@ -235,7 +235,10 @@
     ##' model must be compiled with "OpenMP" support for this to have an
     ##' effect. Returns (invisibly) the previous value.
     ##'
-    ##' @param n_threads The new number of threads to use
+    ##' @param n_threads The new number of threads to use. You may want to
+    ##'   wrap this argument in [dust::dust_openmp_threads()] in order to
+    ##'   verify that you can actually use the number of threads
+    ##'   requested (based on environment variables and OpenMP support).
     set_n_threads = function(n_threads) {
       prev <- private$n_threads_
       dust_{{name}}_set_n_threads(private$ptr_, n_threads)

--- a/inst/template/dust.cpp
+++ b/inst/template/dust.cpp
@@ -83,3 +83,8 @@ bool dust_{{name}}_has_openmp() {
   return false;
 #endif
 }
+
+[[cpp11::register]]
+void dust_{{name}}_set_n_threads(SEXP ptr, int n_threads) {
+  return dust_set_n_threads<{{class}}>(ptr, n_threads);
+}

--- a/man/dust.Rd
+++ b/man/dust.Rd
@@ -506,7 +506,10 @@ effect. Returns (invisibly) the previous value.
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
-\item{\code{n_threads}}{The new number of threads to use}
+\item{\code{n_threads}}{The new number of threads to use. You may want to
+wrap this argument in \code{\link[=dust_openmp_threads]{dust_openmp_threads()}} in order to
+verify that you can actually use the number of threads
+requested (based on environment variables and OpenMP support).}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/dust.Rd
+++ b/man/dust.Rd
@@ -170,6 +170,7 @@ obj$state()
 \item \href{#method-rng_state}{\code{dust_class$rng_state()}}
 \item \href{#method-set_rng_state}{\code{dust_class$set_rng_state()}}
 \item \href{#method-has_openmp}{\code{dust_class$has_openmp()}}
+\item \href{#method-set_n_threads}{\code{dust_class$set_n_threads()}}
 }
 }
 \if{html}{\out{<hr>}}
@@ -490,5 +491,24 @@ as \code{dust_class$public_methods$has_openmp()}
 \if{html}{\out{<div class="r">}}\preformatted{dust_class$has_openmp()}\if{html}{\out{</div>}}
 }
 
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-set_n_threads"></a>}}
+\if{latex}{\out{\hypertarget{method-set_n_threads}{}}}
+\subsection{Method \code{set_n_threads()}}{
+Change the number of threads that the dust object will use. Your
+model must be compiled with "OpenMP" support for this to have an
+effect. Returns (invisibly) the previous value.
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{dust_class$set_n_threads(n_threads)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{n_threads}}{The new number of threads to use}
+}
+\if{html}{\out{</div>}}
+}
 }
 }

--- a/src/cpp11.cpp
+++ b/src/cpp11.cpp
@@ -182,6 +182,14 @@ extern "C" SEXP _dust_dust_sir_has_openmp() {
     return cpp11::as_sexp(dust_sir_has_openmp());
   END_CPP11
 }
+// sir.cpp
+void dust_sir_set_n_threads(SEXP ptr, int n_threads);
+extern "C" SEXP _dust_dust_sir_set_n_threads(SEXP ptr, SEXP n_threads) {
+  BEGIN_CPP11
+    dust_sir_set_n_threads(cpp11::as_cpp<cpp11::decay_t<SEXP>>(ptr), cpp11::as_cpp<cpp11::decay_t<int>>(n_threads));
+    return R_NilValue;
+  END_CPP11
+}
 // variable.cpp
 SEXP dust_variable_alloc(cpp11::list r_data, size_t step, size_t n_particles, size_t n_threads, cpp11::sexp r_seed);
 extern "C" SEXP _dust_dust_variable_alloc(SEXP r_data, SEXP step, SEXP n_particles, SEXP n_threads, SEXP r_seed) {
@@ -272,6 +280,14 @@ bool dust_variable_has_openmp();
 extern "C" SEXP _dust_dust_variable_has_openmp() {
   BEGIN_CPP11
     return cpp11::as_sexp(dust_variable_has_openmp());
+  END_CPP11
+}
+// variable.cpp
+void dust_variable_set_n_threads(SEXP ptr, int n_threads);
+extern "C" SEXP _dust_dust_variable_set_n_threads(SEXP ptr, SEXP n_threads) {
+  BEGIN_CPP11
+    dust_variable_set_n_threads(cpp11::as_cpp<cpp11::decay_t<SEXP>>(ptr), cpp11::as_cpp<cpp11::decay_t<int>>(n_threads));
+    return R_NilValue;
   END_CPP11
 }
 // volatility.cpp
@@ -366,6 +382,14 @@ extern "C" SEXP _dust_dust_volatility_has_openmp() {
     return cpp11::as_sexp(dust_volatility_has_openmp());
   END_CPP11
 }
+// volatility.cpp
+void dust_volatility_set_n_threads(SEXP ptr, int n_threads);
+extern "C" SEXP _dust_dust_volatility_set_n_threads(SEXP ptr, SEXP n_threads) {
+  BEGIN_CPP11
+    dust_volatility_set_n_threads(cpp11::as_cpp<cpp11::decay_t<SEXP>>(ptr), cpp11::as_cpp<cpp11::decay_t<int>>(n_threads));
+    return R_NilValue;
+  END_CPP11
+}
 // walk.cpp
 SEXP dust_walk_alloc(cpp11::list r_data, size_t step, size_t n_particles, size_t n_threads, cpp11::sexp r_seed);
 extern "C" SEXP _dust_dust_walk_alloc(SEXP r_data, SEXP step, SEXP n_particles, SEXP n_threads, SEXP r_seed) {
@@ -458,6 +482,14 @@ extern "C" SEXP _dust_dust_walk_has_openmp() {
     return cpp11::as_sexp(dust_walk_has_openmp());
   END_CPP11
 }
+// walk.cpp
+void dust_walk_set_n_threads(SEXP ptr, int n_threads);
+extern "C" SEXP _dust_dust_walk_set_n_threads(SEXP ptr, SEXP n_threads) {
+  BEGIN_CPP11
+    dust_walk_set_n_threads(cpp11::as_cpp<cpp11::decay_t<SEXP>>(ptr), cpp11::as_cpp<cpp11::decay_t<int>>(n_threads));
+    return R_NilValue;
+  END_CPP11
+}
 
 extern "C" {
 /* .Call calls */
@@ -481,6 +513,7 @@ extern SEXP _dust_dust_sir_rng_state(SEXP, SEXP);
 extern SEXP _dust_dust_sir_run(SEXP, SEXP);
 extern SEXP _dust_dust_sir_set_data(SEXP, SEXP);
 extern SEXP _dust_dust_sir_set_index(SEXP, SEXP);
+extern SEXP _dust_dust_sir_set_n_threads(SEXP, SEXP);
 extern SEXP _dust_dust_sir_set_rng_state(SEXP, SEXP);
 extern SEXP _dust_dust_sir_set_state(SEXP, SEXP, SEXP);
 extern SEXP _dust_dust_sir_simulate(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
@@ -494,6 +527,7 @@ extern SEXP _dust_dust_variable_rng_state(SEXP, SEXP);
 extern SEXP _dust_dust_variable_run(SEXP, SEXP);
 extern SEXP _dust_dust_variable_set_data(SEXP, SEXP);
 extern SEXP _dust_dust_variable_set_index(SEXP, SEXP);
+extern SEXP _dust_dust_variable_set_n_threads(SEXP, SEXP);
 extern SEXP _dust_dust_variable_set_rng_state(SEXP, SEXP);
 extern SEXP _dust_dust_variable_set_state(SEXP, SEXP, SEXP);
 extern SEXP _dust_dust_variable_simulate(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
@@ -507,6 +541,7 @@ extern SEXP _dust_dust_volatility_rng_state(SEXP, SEXP);
 extern SEXP _dust_dust_volatility_run(SEXP, SEXP);
 extern SEXP _dust_dust_volatility_set_data(SEXP, SEXP);
 extern SEXP _dust_dust_volatility_set_index(SEXP, SEXP);
+extern SEXP _dust_dust_volatility_set_n_threads(SEXP, SEXP);
 extern SEXP _dust_dust_volatility_set_rng_state(SEXP, SEXP);
 extern SEXP _dust_dust_volatility_set_state(SEXP, SEXP, SEXP);
 extern SEXP _dust_dust_volatility_simulate(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
@@ -520,6 +555,7 @@ extern SEXP _dust_dust_walk_rng_state(SEXP, SEXP);
 extern SEXP _dust_dust_walk_run(SEXP, SEXP);
 extern SEXP _dust_dust_walk_set_data(SEXP, SEXP);
 extern SEXP _dust_dust_walk_set_index(SEXP, SEXP);
+extern SEXP _dust_dust_walk_set_n_threads(SEXP, SEXP);
 extern SEXP _dust_dust_walk_set_rng_state(SEXP, SEXP);
 extern SEXP _dust_dust_walk_set_state(SEXP, SEXP, SEXP);
 extern SEXP _dust_dust_walk_simulate(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
@@ -547,6 +583,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_dust_dust_sir_run",                  (DL_FUNC) &_dust_dust_sir_run,                  2},
     {"_dust_dust_sir_set_data",             (DL_FUNC) &_dust_dust_sir_set_data,             2},
     {"_dust_dust_sir_set_index",            (DL_FUNC) &_dust_dust_sir_set_index,            2},
+    {"_dust_dust_sir_set_n_threads",        (DL_FUNC) &_dust_dust_sir_set_n_threads,        2},
     {"_dust_dust_sir_set_rng_state",        (DL_FUNC) &_dust_dust_sir_set_rng_state,        2},
     {"_dust_dust_sir_set_state",            (DL_FUNC) &_dust_dust_sir_set_state,            3},
     {"_dust_dust_sir_simulate",             (DL_FUNC) &_dust_dust_sir_simulate,             7},
@@ -560,6 +597,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_dust_dust_variable_run",             (DL_FUNC) &_dust_dust_variable_run,             2},
     {"_dust_dust_variable_set_data",        (DL_FUNC) &_dust_dust_variable_set_data,        2},
     {"_dust_dust_variable_set_index",       (DL_FUNC) &_dust_dust_variable_set_index,       2},
+    {"_dust_dust_variable_set_n_threads",   (DL_FUNC) &_dust_dust_variable_set_n_threads,   2},
     {"_dust_dust_variable_set_rng_state",   (DL_FUNC) &_dust_dust_variable_set_rng_state,   2},
     {"_dust_dust_variable_set_state",       (DL_FUNC) &_dust_dust_variable_set_state,       3},
     {"_dust_dust_variable_simulate",        (DL_FUNC) &_dust_dust_variable_simulate,        7},
@@ -573,6 +611,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_dust_dust_volatility_run",           (DL_FUNC) &_dust_dust_volatility_run,           2},
     {"_dust_dust_volatility_set_data",      (DL_FUNC) &_dust_dust_volatility_set_data,      2},
     {"_dust_dust_volatility_set_index",     (DL_FUNC) &_dust_dust_volatility_set_index,     2},
+    {"_dust_dust_volatility_set_n_threads", (DL_FUNC) &_dust_dust_volatility_set_n_threads, 2},
     {"_dust_dust_volatility_set_rng_state", (DL_FUNC) &_dust_dust_volatility_set_rng_state, 2},
     {"_dust_dust_volatility_set_state",     (DL_FUNC) &_dust_dust_volatility_set_state,     3},
     {"_dust_dust_volatility_simulate",      (DL_FUNC) &_dust_dust_volatility_simulate,      7},
@@ -586,6 +625,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_dust_dust_walk_run",                 (DL_FUNC) &_dust_dust_walk_run,                 2},
     {"_dust_dust_walk_set_data",            (DL_FUNC) &_dust_dust_walk_set_data,            2},
     {"_dust_dust_walk_set_index",           (DL_FUNC) &_dust_dust_walk_set_index,           2},
+    {"_dust_dust_walk_set_n_threads",       (DL_FUNC) &_dust_dust_walk_set_n_threads,       2},
     {"_dust_dust_walk_set_rng_state",       (DL_FUNC) &_dust_dust_walk_set_rng_state,       2},
     {"_dust_dust_walk_set_state",           (DL_FUNC) &_dust_dust_walk_set_state,           3},
     {"_dust_dust_walk_simulate",            (DL_FUNC) &_dust_dust_walk_simulate,            7},

--- a/src/sir.cpp
+++ b/src/sir.cpp
@@ -168,3 +168,8 @@ bool dust_sir_has_openmp() {
   return false;
 #endif
 }
+
+[[cpp11::register]]
+void dust_sir_set_n_threads(SEXP ptr, int n_threads) {
+  return dust_set_n_threads<sir>(ptr, n_threads);
+}

--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -138,3 +138,8 @@ bool dust_variable_has_openmp() {
   return false;
 #endif
 }
+
+[[cpp11::register]]
+void dust_variable_set_n_threads(SEXP ptr, int n_threads) {
+  return dust_set_n_threads<variable>(ptr, n_threads);
+}

--- a/src/volatility.cpp
+++ b/src/volatility.cpp
@@ -133,3 +133,8 @@ bool dust_volatility_has_openmp() {
   return false;
 #endif
 }
+
+[[cpp11::register]]
+void dust_volatility_set_n_threads(SEXP ptr, int n_threads) {
+  return dust_set_n_threads<volatility>(ptr, n_threads);
+}

--- a/src/walk.cpp
+++ b/src/walk.cpp
@@ -115,3 +115,8 @@ bool dust_walk_has_openmp() {
   return false;
 #endif
 }
+
+[[cpp11::register]]
+void dust_walk_set_n_threads(SEXP ptr, int n_threads) {
+  return dust_set_n_threads<walk>(ptr, n_threads);
+}

--- a/tests/testthat/test-interface.R
+++ b/tests/testthat/test-interface.R
@@ -227,6 +227,25 @@ test_that("can return the number of threads initialised with", {
 })
 
 
+test_that("can change the number of threads after initialisation", {
+  mod <- dust_example("walk")$new(list(sd = 1), 0, 5)
+  expect_equal(withVisible(mod$set_n_threads(2)),
+               list(value = 1L, visible = FALSE))
+  expect_equal(mod$n_threads(), 2L)
+  expect_equal(withVisible(mod$set_n_threads(1)),
+               list(value = 2L, visible = FALSE))
+})
+
+
+test_that("can't change to an impossible thread count", {
+  mod <- dust_example("walk")$new(list(sd = 1), 0, 5)
+  expect_error(mod$set_n_threads(0),
+               "'n_threads' must be positive")
+  expect_error(mod$set_n_threads(-1),
+               "'n_threads' must be positive")
+})
+
+
 test_that("number of threads must be positive", {
   res <- dust_example("walk")
   expect_error(


### PR DESCRIPTION
Allows changing the number of threads in an already-initialised dust object. This is needed so that we can dynamically scale the number of cores used for the pmcmc during a run in mcstate.

Fixes #122 
