### PR TITLE
Implement rexp

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dust
 Title: Iterate Multiple Realisations of Stochastic Models
-Version: 0.5.9
+Version: 0.5.10
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("John", "Lees", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# dust 0.5.10
+
+* Add support for `rexp` from dust model, just using inversion for now (#127)
+
 # dust 0.5.9
 
 * Start of support for running dust objects with multiple data/parameter sets at once (#92)

--- a/R/cpp11.R
+++ b/R/cpp11.R
@@ -28,6 +28,10 @@ dust_rng_runif <- function(ptr, n, r_min, r_max) {
   .Call("_dust_dust_rng_runif", ptr, n, r_min, r_max, PACKAGE = "dust")
 }
 
+dust_rng_rexp <- function(ptr, n, r_rate) {
+  .Call("_dust_dust_rng_rexp", ptr, n, r_rate, PACKAGE = "dust")
+}
+
 dust_rng_rnorm <- function(ptr, n, r_mean, r_sd) {
   .Call("_dust_dust_rng_rnorm", ptr, n, r_mean, r_sd, PACKAGE = "dust")
 }

--- a/R/dust_class.R
+++ b/R/dust_class.R
@@ -227,7 +227,7 @@ dust_class <- R6::R6Class(
     ##' @description
     ##' Returns the number of distinct data elements required. This is `0`
     ##' where the object was initialised with `data_multi = FALSE` and
-    ##' an integer otherwise.  For multi-data dust objects, Where `data`
+    ##' an integer otherwise.  For mulit-data dust objects, Where `data`
     ##' is accepted, you must provide an unnamed list of length `$n_data()`.
     n_data = function() {
     },

--- a/R/dust_class.R
+++ b/R/dust_class.R
@@ -227,7 +227,7 @@ dust_class <- R6::R6Class(
     ##' @description
     ##' Returns the number of distinct data elements required. This is `0`
     ##' where the object was initialised with `data_multi = FALSE` and
-    ##' an integer otherwise.  For mulit-data dust objects, Where `data`
+    ##' an integer otherwise.  For multi-data dust objects, Where `data`
     ##' is accepted, you must provide an unnamed list of length `$n_data()`.
     n_data = function() {
     },

--- a/R/rng.R
+++ b/R/rng.R
@@ -122,6 +122,15 @@ dust_rng <- R6::R6Class(
       dust_rng_rpois(private$ptr, n, recycle(lambda, n))
     },
 
+    ##' Generate `n` numbers from a exponential distribution
+    ##'
+    ##' @param n Number of samples to draw
+    ##'
+    ##' @param rate The rate of the exponential
+    rexp = function(n, rate) {
+      dust_rng_rexp(private$ptr, n, recycle(rate, n))
+    },
+
     ##' @description
     ##' Returns the state of the random number generator. This returns a
     ##' raw vector of length 32 * n_generators. It is primarily intended for

--- a/inst/include/dust/distr/exponential.hpp
+++ b/inst/include/dust/distr/exponential.hpp
@@ -17,7 +17,7 @@ namespace distr {
 // important.
 template <typename real_t>
 real_t exp_rand(rng_state_t<real_t>& rng_state) {
-  return -log(dust::unif_rand(rng_state));
+  return -std::log(dust::unif_rand(rng_state));
 }
 
 template <typename real_t>

--- a/inst/include/dust/distr/exponential.hpp
+++ b/inst/include/dust/distr/exponential.hpp
@@ -1,0 +1,31 @@
+#ifndef DUST_DISTR_EXPONENTIAL_HPP
+#define DUST_DISTR_EXPONENTIAL_HPP
+
+#include <cmath>
+
+namespace dust {
+namespace distr {
+
+// Devroye 1986
+// http://luc.devroye.org/rnbookindex.html
+// Chapter 9, p 392
+//
+// > No method is shorter than the inversion method, which returns
+// > -log(U) where U is a uniform [0,1] random variate
+//
+// Faster generators will exist but we can swap one in if it becomes
+// important.
+template <typename real_t>
+real_t exp_rand(rng_state_t<real_t>& rng_state) {
+  return -log(dust::unif_rand(rng_state));
+}
+
+template <typename real_t>
+real_t rexp(rng_state_t<real_t>& rng_state, real_t rate) {
+  return exp_rand(rng_state) / rate;
+}
+
+}
+}
+
+#endif

--- a/inst/include/dust/rng.hpp
+++ b/inst/include/dust/rng.hpp
@@ -4,6 +4,7 @@
 #include <algorithm>
 #include "xoshiro.hpp"
 #include "distr/binomial.hpp"
+#include "distr/exponential.hpp"
 #include "distr/normal.hpp"
 #include "distr/poisson.hpp"
 #include "distr/uniform.hpp"

--- a/inst/template/dust.R.template
+++ b/inst/template/dust.R.template
@@ -274,7 +274,7 @@
     ##' @description
     ##' Returns the number of distinct data elements required. This is `0`
     ##' where the object was initialised with `data_multi = FALSE` and
-    ##' an integer otherwise.  For mulit-data dust objects, Where `data`
+    ##' an integer otherwise.  For multi-data dust objects, Where `data`
     ##' is accepted, you must provide an unnamed list of length `$n_data()`.
     n_data = function() {
       if (private$data_multi_) length(private$data_) else 0L

--- a/man/dust.Rd
+++ b/man/dust.Rd
@@ -523,7 +523,7 @@ as \code{dust_class$public_methods$has_openmp()}
 \subsection{Method \code{n_data()}}{
 Returns the number of distinct data elements required. This is \code{0}
 where the object was initialised with \code{data_multi = FALSE} and
-an integer otherwise.  For mulit-data dust objects, Where \code{data}
+an integer otherwise.  For multi-data dust objects, Where \code{data}
 is accepted, you must provide an unnamed list of length \verb{$n_data()}.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{dust_class$n_data()}\if{html}{\out{</div>}}

--- a/man/dust_rng.Rd
+++ b/man/dust_rng.Rd
@@ -42,6 +42,7 @@ rng$rpois(5, 2)
 \item \href{#method-rnorm}{\code{dust_rng$rnorm()}}
 \item \href{#method-rbinom}{\code{dust_rng$rbinom()}}
 \item \href{#method-rpois}{\code{dust_rng$rpois()}}
+\item \href{#method-rexp}{\code{dust_rng$rexp()}}
 \item \href{#method-state}{\code{dust_rng$state()}}
 }
 }
@@ -210,7 +211,26 @@ Generate \code{n} numbers from a Poisson distribution}
 \describe{
 \item{\code{n}}{Number of samples to draw}
 
-\item{\code{lambda}}{The mean (zero or more, length 1 or n)}
+\item{\code{lambda}}{The mean (zero or more, length 1 or n)
+Generate \code{n} numbers from a exponential distribution}
+}
+\if{html}{\out{</div>}}
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-rexp"></a>}}
+\if{latex}{\out{\hypertarget{method-rexp}{}}}
+\subsection{Method \code{rexp()}}{
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{dust_rng$rexp(n, rate)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{n}}{Number of samples to draw}
+
+\item{\code{rate}}{The rate of the exponential}
 }
 \if{html}{\out{</div>}}
 }

--- a/src/cpp11.cpp
+++ b/src/cpp11.cpp
@@ -56,6 +56,13 @@ extern "C" SEXP _dust_dust_rng_runif(SEXP ptr, SEXP n, SEXP r_min, SEXP r_max) {
   END_CPP11
 }
 // dust_rng.cpp
+cpp11::writable::doubles dust_rng_rexp(SEXP ptr, int n, cpp11::doubles r_rate);
+extern "C" SEXP _dust_dust_rng_rexp(SEXP ptr, SEXP n, SEXP r_rate) {
+  BEGIN_CPP11
+    return cpp11::as_sexp(dust_rng_rexp(cpp11::as_cpp<cpp11::decay_t<SEXP>>(ptr), cpp11::as_cpp<cpp11::decay_t<int>>(n), cpp11::as_cpp<cpp11::decay_t<cpp11::doubles>>(r_rate)));
+  END_CPP11
+}
+// dust_rng.cpp
 cpp11::writable::doubles dust_rng_rnorm(SEXP ptr, int n, cpp11::doubles r_mean, cpp11::doubles r_sd);
 extern "C" SEXP _dust_dust_rng_rnorm(SEXP ptr, SEXP n, SEXP r_mean, SEXP r_sd) {
   BEGIN_CPP11
@@ -499,6 +506,7 @@ extern SEXP _dust_dust_rng_jump(SEXP);
 extern SEXP _dust_dust_rng_long_jump(SEXP);
 extern SEXP _dust_dust_rng_norm_rand(SEXP, SEXP);
 extern SEXP _dust_dust_rng_rbinom(SEXP, SEXP, SEXP, SEXP);
+extern SEXP _dust_dust_rng_rexp(SEXP, SEXP, SEXP);
 extern SEXP _dust_dust_rng_rnorm(SEXP, SEXP, SEXP, SEXP);
 extern SEXP _dust_dust_rng_rpois(SEXP, SEXP, SEXP);
 extern SEXP _dust_dust_rng_runif(SEXP, SEXP, SEXP, SEXP);
@@ -569,6 +577,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_dust_dust_rng_long_jump",            (DL_FUNC) &_dust_dust_rng_long_jump,            1},
     {"_dust_dust_rng_norm_rand",            (DL_FUNC) &_dust_dust_rng_norm_rand,            2},
     {"_dust_dust_rng_rbinom",               (DL_FUNC) &_dust_dust_rng_rbinom,               4},
+    {"_dust_dust_rng_rexp",                 (DL_FUNC) &_dust_dust_rng_rexp,                 3},
     {"_dust_dust_rng_rnorm",                (DL_FUNC) &_dust_dust_rng_rnorm,                4},
     {"_dust_dust_rng_rpois",                (DL_FUNC) &_dust_dust_rng_rpois,                3},
     {"_dust_dust_rng_runif",                (DL_FUNC) &_dust_dust_rng_runif,                4},

--- a/src/dust_rng.cpp
+++ b/src/dust_rng.cpp
@@ -67,8 +67,8 @@ cpp11::writable::doubles dust_rng_norm_rand(SEXP ptr, int n) {
 
 [[cpp11::register]]
 cpp11::writable::doubles dust_rng_runif(SEXP ptr, int n,
-                                         cpp11::doubles r_min,
-                                         cpp11::doubles r_max) {
+                                        cpp11::doubles r_min,
+                                        cpp11::doubles r_max) {
   dust_rng_t *rng = cpp11::as_cpp<dust_rng_ptr_t>(ptr).get();
   const double * min = REAL(r_min);
   const double * max = REAL(r_max);
@@ -79,6 +79,23 @@ cpp11::writable::doubles dust_rng_runif(SEXP ptr, int n,
 
   for (size_t i = 0; i < (size_t)n; ++i) {
     y[i] = dust::distr::runif(rng->state(i % n_generators), min[i], max[i]);
+  }
+
+  return ret;
+}
+
+[[cpp11::register]]
+cpp11::writable::doubles dust_rng_rexp(SEXP ptr, int n,
+                                       cpp11::doubles r_rate) {
+  dust_rng_t *rng = cpp11::as_cpp<dust_rng_ptr_t>(ptr).get();
+  const double * rate = REAL(r_rate);
+  const size_t n_generators = rng->size();
+
+  cpp11::writable::doubles ret = cpp11::writable::doubles(n);
+  double * y = REAL(ret);
+
+  for (size_t i = 0; i < (size_t)n; ++i) {
+    y[i] = dust::distr::rexp(rng->state(i % n_generators), rate[i]);
   }
 
   return ret;

--- a/tests/testthat/test-rng.R
+++ b/tests/testthat/test-rng.R
@@ -187,6 +187,16 @@ test_that("rnorm agrees with stats::rnorm", {
 })
 
 
+test_that("rnorm agrees with stats::rnorm", {
+  n <- 100000
+  rate <- 0.04
+  ans <- dust_rng$new(2, 1)$rexp(n, rate)
+  expect_equal(mean(ans), 1 / rate, tolerance = 1e-2)
+  expect_equal(var(ans), 1 / rate^2, tolerance = 1e-2)
+  expect_gt(ks.test(ans, "pexp", rate)$p.value, 0.1)
+})
+
+
 test_that("continue stream", {
   rng1 <- dust_rng$new(1, 1L)
   rng2 <- dust_rng$new(1, 1L)

--- a/tests/testthat/test-rng.R
+++ b/tests/testthat/test-rng.R
@@ -187,7 +187,7 @@ test_that("rnorm agrees with stats::rnorm", {
 })
 
 
-test_that("rnorm agrees with stats::rnorm", {
+test_that("rexp agrees with stats::rexp", {
   n <- 100000
   rate <- 0.04
   ans <- dust_rng$new(2, 1)$rexp(n, rate)


### PR DESCRIPTION
Basic implementation of exponential random samples. Requires log() but at least it's really easy to understand.

Fixes #127