### PR TITLE
Add methods n_particles and n_state to dust models

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dust
 Title: Iterate Multiple Realisations of Stochastic Models
-Version: 0.7.1
+Version: 0.7.2
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("John", "Lees", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# dust 0.7.2
+
+* Added new methods `$n_particles()` and `$n_state()` to every dust model which can be used to query the size of the state (#149)
+
 # dust 0.7.0
 
 * Dust models must now specify two internal types, `internal_t` and `shared_t`. The latter is a pointer to constant data shared across all particles within a parameter set (#143)

--- a/R/cpp11.R
+++ b/R/cpp11.R
@@ -132,6 +132,10 @@ dust_sir_set_n_threads <- function(ptr, n_threads) {
   invisible(.Call(`_dust_dust_sir_set_n_threads`, ptr, n_threads))
 }
 
+dust_sir_n_state <- function(ptr) {
+  .Call(`_dust_dust_sir_n_state`, ptr)
+}
+
 dust_variable_alloc <- function(r_pars, pars_multi, step, n_particles, n_threads, r_seed) {
   .Call(`_dust_dust_variable_alloc`, r_pars, pars_multi, step, n_particles, n_threads, r_seed)
 }
@@ -194,6 +198,10 @@ dust_variable_capabilities <- function() {
 
 dust_variable_set_n_threads <- function(ptr, n_threads) {
   invisible(.Call(`_dust_dust_variable_set_n_threads`, ptr, n_threads))
+}
+
+dust_variable_n_state <- function(ptr) {
+  .Call(`_dust_dust_variable_n_state`, ptr)
 }
 
 dust_volatility_alloc <- function(r_pars, pars_multi, step, n_particles, n_threads, r_seed) {
@@ -260,6 +268,10 @@ dust_volatility_set_n_threads <- function(ptr, n_threads) {
   invisible(.Call(`_dust_dust_volatility_set_n_threads`, ptr, n_threads))
 }
 
+dust_volatility_n_state <- function(ptr) {
+  .Call(`_dust_dust_volatility_n_state`, ptr)
+}
+
 dust_walk_alloc <- function(r_pars, pars_multi, step, n_particles, n_threads, r_seed) {
   .Call(`_dust_dust_walk_alloc`, r_pars, pars_multi, step, n_particles, n_threads, r_seed)
 }
@@ -322,4 +334,8 @@ dust_walk_capabilities <- function() {
 
 dust_walk_set_n_threads <- function(ptr, n_threads) {
   invisible(.Call(`_dust_dust_walk_set_n_threads`, ptr, n_threads))
+}
+
+dust_walk_n_state <- function(ptr) {
+  .Call(`_dust_dust_walk_n_state`, ptr)
 }

--- a/R/dust.R
+++ b/R/dust.R
@@ -9,6 +9,7 @@ sir <- R6::R6Class(
     index_ = NULL,
     info_ = NULL,
     n_threads_ = NULL,
+    n_particles_ = NULL,
     ptr_ = NULL,
     param_ = list(beta = list(required = FALSE), gamma = list(required = FALSE)),
 
@@ -43,6 +44,7 @@ sir <- R6::R6Class(
       private$pars_ <- pars
       private$pars_multi_ <- pars_multi
       private$n_threads_ <- n_threads
+      private$n_particles_ <- n_particles
       private$ptr_ <- res[[1L]]
       private$info_ <- res[[2L]]
     },
@@ -73,6 +75,14 @@ sir <- R6::R6Class(
 
     n_threads = function() {
       private$n_threads_
+    },
+
+    n_state = function() {
+      dust_sir_n_state(private$ptr_)
+    },
+
+    n_particles = function() {
+      private$n_particles_
     },
 
     set_state = function(state, step = NULL) {
@@ -168,6 +178,7 @@ variable <- R6::R6Class(
     index_ = NULL,
     info_ = NULL,
     n_threads_ = NULL,
+    n_particles_ = NULL,
     ptr_ = NULL,
     param_ = NULL,
 
@@ -202,6 +213,7 @@ variable <- R6::R6Class(
       private$pars_ <- pars
       private$pars_multi_ <- pars_multi
       private$n_threads_ <- n_threads
+      private$n_particles_ <- n_particles
       private$ptr_ <- res[[1L]]
       private$info_ <- res[[2L]]
     },
@@ -232,6 +244,14 @@ variable <- R6::R6Class(
 
     n_threads = function() {
       private$n_threads_
+    },
+
+    n_state = function() {
+      dust_variable_n_state(private$ptr_)
+    },
+
+    n_particles = function() {
+      private$n_particles_
     },
 
     set_state = function(state, step = NULL) {
@@ -327,6 +347,7 @@ volatility <- R6::R6Class(
     index_ = NULL,
     info_ = NULL,
     n_threads_ = NULL,
+    n_particles_ = NULL,
     ptr_ = NULL,
     param_ = NULL,
 
@@ -361,6 +382,7 @@ volatility <- R6::R6Class(
       private$pars_ <- pars
       private$pars_multi_ <- pars_multi
       private$n_threads_ <- n_threads
+      private$n_particles_ <- n_particles
       private$ptr_ <- res[[1L]]
       private$info_ <- res[[2L]]
     },
@@ -391,6 +413,14 @@ volatility <- R6::R6Class(
 
     n_threads = function() {
       private$n_threads_
+    },
+
+    n_state = function() {
+      dust_volatility_n_state(private$ptr_)
+    },
+
+    n_particles = function() {
+      private$n_particles_
     },
 
     set_state = function(state, step = NULL) {
@@ -486,6 +516,7 @@ walk <- R6::R6Class(
     index_ = NULL,
     info_ = NULL,
     n_threads_ = NULL,
+    n_particles_ = NULL,
     ptr_ = NULL,
     param_ = NULL,
 
@@ -520,6 +551,7 @@ walk <- R6::R6Class(
       private$pars_ <- pars
       private$pars_multi_ <- pars_multi
       private$n_threads_ <- n_threads
+      private$n_particles_ <- n_particles
       private$ptr_ <- res[[1L]]
       private$info_ <- res[[2L]]
     },
@@ -550,6 +582,14 @@ walk <- R6::R6Class(
 
     n_threads = function() {
       private$n_threads_
+    },
+
+    n_state = function() {
+      dust_walk_n_state(private$ptr_)
+    },
+
+    n_particles = function() {
+      private$n_particles_
     },
 
     set_state = function(state, step = NULL) {

--- a/R/dust_class.R
+++ b/R/dust_class.R
@@ -18,6 +18,7 @@ dust_class <- R6::R6Class(
     index_ = NULL,
     info_ = NULL,
     n_threads_ = NULL,
+    n_particles_ = NULL,
     ptr_ = NULL,
     param_ = NULL,
 
@@ -118,6 +119,16 @@ dust_class <- R6::R6Class(
     ##' @description
     ##' Returns the number of threads that the model was constructed with
     n_threads = function() {
+    },
+
+    ##' @description
+    ##' Returns the length of the per-particle state
+    n_state = function() {
+    },
+
+    ##' @description
+    ##' Returns the number of particles
+    n_particles = function() {
     },
 
     ##' @description

--- a/inst/include/dust/interface.hpp
+++ b/inst/include/dust/interface.hpp
@@ -464,6 +464,12 @@ cpp11::sexp dust_capabilities() {
   return cpp11::writable::list({"openmp"_nm = openmp, "compare"_nm = compare});
 }
 
+template <typename T>
+int dust_n_state(SEXP ptr) {
+  Dust<T> *obj = cpp11::as_cpp<cpp11::external_pointer<Dust<T>>>(ptr).get();
+  return obj->n_state_full();
+}
+
 inline void validate_size(int x, const char * name) {
   if (x < 0) {
     cpp11::stop("'%s' must be non-negative", name);

--- a/inst/template/dust.R.template
+++ b/inst/template/dust.R.template
@@ -8,6 +8,7 @@
     index_ = NULL,
     info_ = NULL,
     n_threads_ = NULL,
+    n_particles_ = NULL,
     ptr_ = NULL,
     param_ = {{param}},
 
@@ -82,6 +83,7 @@
       private$pars_ <- pars
       private$pars_multi_ <- pars_multi
       private$n_threads_ <- n_threads
+      private$n_particles_ <- n_particles
       private$ptr_ <- res[[1L]]
       private$info_ <- res[[2L]]
     },
@@ -139,6 +141,18 @@
     ##' Returns the number of threads that the model was constructed with
     n_threads = function() {
       private$n_threads_
+    },
+
+    ##' @description
+    ##' Returns the length of the per-particle state
+    n_state = function() {
+      dust_{{name}}_n_state(private$ptr_)
+    },
+
+    ##' @description
+    ##' Returns the number of particles
+    n_particles = function() {
+      private$n_particles_
     },
 
     ##' @description

--- a/inst/template/dust.cpp
+++ b/inst/template/dust.cpp
@@ -97,3 +97,9 @@ cpp11::sexp dust_{{name}}_capabilities() {
 void dust_{{name}}_set_n_threads(SEXP ptr, int n_threads) {
   return dust_set_n_threads<{{class}}>(ptr, n_threads);
 }
+
+
+[[cpp11::register]]
+int dust_{{name}}_n_state(SEXP ptr) {
+  return dust_n_state<{{class}}>(ptr);
+}

--- a/man/dust.Rd
+++ b/man/dust.Rd
@@ -178,6 +178,8 @@ obj$state()
 \item \href{#method-set_index}{\code{dust_class$set_index()}}
 \item \href{#method-index}{\code{dust_class$index()}}
 \item \href{#method-n_threads}{\code{dust_class$n_threads()}}
+\item \href{#method-n_state}{\code{dust_class$n_state()}}
+\item \href{#method-n_particles}{\code{dust_class$n_particles()}}
 \item \href{#method-set_state}{\code{dust_class$set_state()}}
 \item \href{#method-reset}{\code{dust_class$reset()}}
 \item \href{#method-set_pars}{\code{dust_class$set_pars()}}
@@ -338,6 +340,26 @@ Returns the \code{index} as set by \verb{$set_index}
 Returns the number of threads that the model was constructed with
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{dust_class$n_threads()}\if{html}{\out{</div>}}
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-n_state"></a>}}
+\if{latex}{\out{\hypertarget{method-n_state}{}}}
+\subsection{Method \code{n_state()}}{
+Returns the length of the per-particle state
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{dust_class$n_state()}\if{html}{\out{</div>}}
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-n_particles"></a>}}
+\if{latex}{\out{\hypertarget{method-n_particles}{}}}
+\subsection{Method \code{n_particles()}}{
+Returns the number of particles
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{dust_class$n_particles()}\if{html}{\out{</div>}}
 }
 
 }

--- a/src/cpp11.cpp
+++ b/src/cpp11.cpp
@@ -239,6 +239,13 @@ extern "C" SEXP _dust_dust_sir_set_n_threads(SEXP ptr, SEXP n_threads) {
     return R_NilValue;
   END_CPP11
 }
+// sir.cpp
+int dust_sir_n_state(SEXP ptr);
+extern "C" SEXP _dust_dust_sir_n_state(SEXP ptr) {
+  BEGIN_CPP11
+    return cpp11::as_sexp(dust_sir_n_state(cpp11::as_cpp<cpp11::decay_t<SEXP>>(ptr)));
+  END_CPP11
+}
 // variable.cpp
 SEXP dust_variable_alloc(cpp11::list r_pars, bool pars_multi, size_t step, size_t n_particles, size_t n_threads, cpp11::sexp r_seed);
 extern "C" SEXP _dust_dust_variable_alloc(SEXP r_pars, SEXP pars_multi, SEXP step, SEXP n_particles, SEXP n_threads, SEXP r_seed) {
@@ -351,6 +358,13 @@ extern "C" SEXP _dust_dust_variable_set_n_threads(SEXP ptr, SEXP n_threads) {
   BEGIN_CPP11
     dust_variable_set_n_threads(cpp11::as_cpp<cpp11::decay_t<SEXP>>(ptr), cpp11::as_cpp<cpp11::decay_t<int>>(n_threads));
     return R_NilValue;
+  END_CPP11
+}
+// variable.cpp
+int dust_variable_n_state(SEXP ptr);
+extern "C" SEXP _dust_dust_variable_n_state(SEXP ptr) {
+  BEGIN_CPP11
+    return cpp11::as_sexp(dust_variable_n_state(cpp11::as_cpp<cpp11::decay_t<SEXP>>(ptr)));
   END_CPP11
 }
 // volatility.cpp
@@ -467,6 +481,13 @@ extern "C" SEXP _dust_dust_volatility_set_n_threads(SEXP ptr, SEXP n_threads) {
     return R_NilValue;
   END_CPP11
 }
+// volatility.cpp
+int dust_volatility_n_state(SEXP ptr);
+extern "C" SEXP _dust_dust_volatility_n_state(SEXP ptr) {
+  BEGIN_CPP11
+    return cpp11::as_sexp(dust_volatility_n_state(cpp11::as_cpp<cpp11::decay_t<SEXP>>(ptr)));
+  END_CPP11
+}
 // walk.cpp
 SEXP dust_walk_alloc(cpp11::list r_pars, bool pars_multi, size_t step, size_t n_particles, size_t n_threads, cpp11::sexp r_seed);
 extern "C" SEXP _dust_dust_walk_alloc(SEXP r_pars, SEXP pars_multi, SEXP step, SEXP n_particles, SEXP n_threads, SEXP r_seed) {
@@ -581,6 +602,13 @@ extern "C" SEXP _dust_dust_walk_set_n_threads(SEXP ptr, SEXP n_threads) {
     return R_NilValue;
   END_CPP11
 }
+// walk.cpp
+int dust_walk_n_state(SEXP ptr);
+extern "C" SEXP _dust_dust_walk_n_state(SEXP ptr) {
+  BEGIN_CPP11
+    return cpp11::as_sexp(dust_walk_n_state(cpp11::as_cpp<cpp11::decay_t<SEXP>>(ptr)));
+  END_CPP11
+}
 
 extern "C" {
 /* .Call calls */
@@ -604,6 +632,7 @@ extern SEXP _dust_dust_rng_unif_rand(SEXP, SEXP);
 extern SEXP _dust_dust_sir_alloc(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP _dust_dust_sir_capabilities();
 extern SEXP _dust_dust_sir_compare_data(SEXP);
+extern SEXP _dust_dust_sir_n_state(SEXP);
 extern SEXP _dust_dust_sir_reorder(SEXP, SEXP);
 extern SEXP _dust_dust_sir_reset(SEXP, SEXP, SEXP);
 extern SEXP _dust_dust_sir_rng_state(SEXP, SEXP);
@@ -620,6 +649,7 @@ extern SEXP _dust_dust_sir_step(SEXP);
 extern SEXP _dust_dust_variable_alloc(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP _dust_dust_variable_capabilities();
 extern SEXP _dust_dust_variable_compare_data(SEXP);
+extern SEXP _dust_dust_variable_n_state(SEXP);
 extern SEXP _dust_dust_variable_reorder(SEXP, SEXP);
 extern SEXP _dust_dust_variable_reset(SEXP, SEXP, SEXP);
 extern SEXP _dust_dust_variable_rng_state(SEXP, SEXP);
@@ -636,6 +666,7 @@ extern SEXP _dust_dust_variable_step(SEXP);
 extern SEXP _dust_dust_volatility_alloc(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP _dust_dust_volatility_capabilities();
 extern SEXP _dust_dust_volatility_compare_data(SEXP);
+extern SEXP _dust_dust_volatility_n_state(SEXP);
 extern SEXP _dust_dust_volatility_reorder(SEXP, SEXP);
 extern SEXP _dust_dust_volatility_reset(SEXP, SEXP, SEXP);
 extern SEXP _dust_dust_volatility_rng_state(SEXP, SEXP);
@@ -652,6 +683,7 @@ extern SEXP _dust_dust_volatility_step(SEXP);
 extern SEXP _dust_dust_walk_alloc(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP _dust_dust_walk_capabilities();
 extern SEXP _dust_dust_walk_compare_data(SEXP);
+extern SEXP _dust_dust_walk_n_state(SEXP);
 extern SEXP _dust_dust_walk_reorder(SEXP, SEXP);
 extern SEXP _dust_dust_walk_reset(SEXP, SEXP, SEXP);
 extern SEXP _dust_dust_walk_rng_state(SEXP, SEXP);
@@ -687,6 +719,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_dust_dust_sir_alloc",                (DL_FUNC) &_dust_dust_sir_alloc,                6},
     {"_dust_dust_sir_capabilities",         (DL_FUNC) &_dust_dust_sir_capabilities,         0},
     {"_dust_dust_sir_compare_data",         (DL_FUNC) &_dust_dust_sir_compare_data,         1},
+    {"_dust_dust_sir_n_state",              (DL_FUNC) &_dust_dust_sir_n_state,              1},
     {"_dust_dust_sir_reorder",              (DL_FUNC) &_dust_dust_sir_reorder,              2},
     {"_dust_dust_sir_reset",                (DL_FUNC) &_dust_dust_sir_reset,                3},
     {"_dust_dust_sir_rng_state",            (DL_FUNC) &_dust_dust_sir_rng_state,            2},
@@ -703,6 +736,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_dust_dust_variable_alloc",           (DL_FUNC) &_dust_dust_variable_alloc,           6},
     {"_dust_dust_variable_capabilities",    (DL_FUNC) &_dust_dust_variable_capabilities,    0},
     {"_dust_dust_variable_compare_data",    (DL_FUNC) &_dust_dust_variable_compare_data,    1},
+    {"_dust_dust_variable_n_state",         (DL_FUNC) &_dust_dust_variable_n_state,         1},
     {"_dust_dust_variable_reorder",         (DL_FUNC) &_dust_dust_variable_reorder,         2},
     {"_dust_dust_variable_reset",           (DL_FUNC) &_dust_dust_variable_reset,           3},
     {"_dust_dust_variable_rng_state",       (DL_FUNC) &_dust_dust_variable_rng_state,       2},
@@ -719,6 +753,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_dust_dust_volatility_alloc",         (DL_FUNC) &_dust_dust_volatility_alloc,         6},
     {"_dust_dust_volatility_capabilities",  (DL_FUNC) &_dust_dust_volatility_capabilities,  0},
     {"_dust_dust_volatility_compare_data",  (DL_FUNC) &_dust_dust_volatility_compare_data,  1},
+    {"_dust_dust_volatility_n_state",       (DL_FUNC) &_dust_dust_volatility_n_state,       1},
     {"_dust_dust_volatility_reorder",       (DL_FUNC) &_dust_dust_volatility_reorder,       2},
     {"_dust_dust_volatility_reset",         (DL_FUNC) &_dust_dust_volatility_reset,         3},
     {"_dust_dust_volatility_rng_state",     (DL_FUNC) &_dust_dust_volatility_rng_state,     2},
@@ -735,6 +770,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_dust_dust_walk_alloc",               (DL_FUNC) &_dust_dust_walk_alloc,               6},
     {"_dust_dust_walk_capabilities",        (DL_FUNC) &_dust_dust_walk_capabilities,        0},
     {"_dust_dust_walk_compare_data",        (DL_FUNC) &_dust_dust_walk_compare_data,        1},
+    {"_dust_dust_walk_n_state",             (DL_FUNC) &_dust_dust_walk_n_state,             1},
     {"_dust_dust_walk_reorder",             (DL_FUNC) &_dust_dust_walk_reorder,             2},
     {"_dust_dust_walk_reset",               (DL_FUNC) &_dust_dust_walk_reset,               3},
     {"_dust_dust_walk_rng_state",           (DL_FUNC) &_dust_dust_walk_rng_state,           2},

--- a/src/sir.cpp
+++ b/src/sir.cpp
@@ -191,3 +191,9 @@ cpp11::sexp dust_sir_capabilities() {
 void dust_sir_set_n_threads(SEXP ptr, int n_threads) {
   return dust_set_n_threads<sir>(ptr, n_threads);
 }
+
+
+[[cpp11::register]]
+int dust_sir_n_state(SEXP ptr) {
+  return dust_n_state<sir>(ptr);
+}

--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -157,3 +157,9 @@ cpp11::sexp dust_variable_capabilities() {
 void dust_variable_set_n_threads(SEXP ptr, int n_threads) {
   return dust_set_n_threads<variable>(ptr, n_threads);
 }
+
+
+[[cpp11::register]]
+int dust_variable_n_state(SEXP ptr) {
+  return dust_n_state<variable>(ptr);
+}

--- a/src/volatility.cpp
+++ b/src/volatility.cpp
@@ -152,3 +152,9 @@ cpp11::sexp dust_volatility_capabilities() {
 void dust_volatility_set_n_threads(SEXP ptr, int n_threads) {
   return dust_set_n_threads<volatility>(ptr, n_threads);
 }
+
+
+[[cpp11::register]]
+int dust_volatility_n_state(SEXP ptr) {
+  return dust_n_state<volatility>(ptr);
+}

--- a/src/walk.cpp
+++ b/src/walk.cpp
@@ -136,3 +136,9 @@ cpp11::sexp dust_walk_capabilities() {
 void dust_walk_set_n_threads(SEXP ptr, int n_threads) {
   return dust_set_n_threads<walk>(ptr, n_threads);
 }
+
+
+[[cpp11::register]]
+int dust_walk_n_state(SEXP ptr) {
+  return dust_n_state<walk>(ptr);
+}

--- a/tests/testthat/test-example.R
+++ b/tests/testthat/test-example.R
@@ -495,3 +495,13 @@ test_that("Can run compare_data", {
   modelled <- drop(mod$state(5))
   expect_equal(dpois(d[[10]][[2]]$incidence, modelled, log = TRUE), x)
 })
+
+
+test_that("fetch model size", {
+  res <- dust_example("variable")
+  mod <- res$new(list(len = 10), 0, 7, seed = 1L)
+  expect_equal(mod$n_particles(), 7)
+  expect_equal(mod$n_state(), 10)
+  mod$set_index(c(3, 5, 7))
+  expect_equal(mod$n_state(), 10)
+})


### PR DESCRIPTION
This would have been useful in https://github.com/mrc-ide/mcstate/pull/79/files for storing the restart state; I can fix that up later. Having easy access to these numbers means we can construct the correct size arrays up front.

Fixes #149 