### PR TITLE
Fix corner case in dnbinom

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dust
 Title: Iterate Multiple Realisations of Stochastic Models
-Version: 0.7.6
+Version: 0.7.7
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("John", "Lees", role = "aut"),

--- a/inst/include/dust/densities.hpp
+++ b/inst/include/dust/densities.hpp
@@ -36,8 +36,7 @@ T dbinom(int x, int size, T prob, bool log) {
 
 template <typename T>
 T ddelta(T x, bool log) {
-  constexpr T inf = std::numeric_limits<T>::infinity();
-  return maybe_log(x == 0 ? inf : -inf, log);
+  return maybe_log(x == 0 ? 0 : -std::numeric_limits<T>::infinity(), log);
 }
 
 template <typename T>
@@ -61,7 +60,7 @@ T dnbinom(int x, T size, T mu, bool log) {
     return maybe_log(-std::numeric_limits<T>::infinity(), log);
   }
   if (mu == 0) {
-    return ddelta(x, log);
+    return ddelta(static_cast<T>(x), log);
   }
   const T ret = std::lgamma(static_cast<T>(x + size)) -
     std::lgamma(static_cast<T>(size)) -

--- a/inst/include/dust/densities.hpp
+++ b/inst/include/dust/densities.hpp
@@ -36,7 +36,8 @@ T dbinom(int x, int size, T prob, bool log) {
 
 template <typename T>
 T ddelta(T x, bool log) {
-  return maybe_log(x == 0 ? 0 : -std::numeric_limits<T>::infinity(), log);
+  constexpr T inf = std::numeric_limits<T>::infinity();
+  return maybe_log(x == 0 ? inf : -inf, log);
 }
 
 template <typename T>
@@ -60,7 +61,7 @@ T dnbinom(int x, T size, T mu, bool log) {
     return maybe_log(-std::numeric_limits<T>::infinity(), log);
   }
   if (mu == 0) {
-    return ddelta(static_cast<T>(x), log);
+    return maybe_log(x == 0 ? 0 : -std::numeric_limits<T>::infinity(), log);
   }
   const T ret = std::lgamma(static_cast<T>(x + size)) -
     std::lgamma(static_cast<T>(size)) -

--- a/tests/testthat/test-densities.R
+++ b/tests/testthat/test-densities.R
@@ -98,10 +98,18 @@ test_that("dnbinom agrees", {
     dnbinom(x = 0, size = 2, mu = 0, log = FALSE))
   expect_equal(
     dust_dnbinom(x = 1L, size = 2, mu = 0, log = TRUE),
-    dnbinom(x = 0, size = 2, mu = 0, log = TRUE))
+    dnbinom(x = 1, size = 2, mu = 0, log = TRUE))
   expect_equal(
     dust_dnbinom(x = 1L, size = 2, mu = 0, log = FALSE),
-    dnbinom(x = 0, size = 2, mu = 0, log = FALSE))
+    dnbinom(x = 1, size = 2, mu = 0, log = FALSE))
+
+  ## Special case where mu is zero
+  expect_equal(
+    dnbinom(34, 2, mu = 0, log = TRUE),
+    dust_dnbinom(34L, 2, 0, TRUE))
+  expect_equal(
+    dnbinom(34, 2, mu = 0, log = FALSE),
+    dust_dnbinom(34L, 2, 0, FALSE))
 })
 
 


### PR DESCRIPTION
Managed to use ddelta incorrectly for the discrete distribution, so I've swapped that now.