### PR TITLE
Fix use of utils in device code

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dust
 Title: Iterate Multiple Realisations of Stochastic Models
-Version: 0.8.2
+Version: 0.8.3
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("John", "Lees", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# dust 0.8.3
+
+* Fix issue with `rnorm()` running on a GPU (device code).
+
 # dust 0.8.2
 
 * Don't rewrite files with identical content during generation; this avoids recompilation of code across sessions when the argument `workdir` is used with `dust::dust` (#195)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # dust 0.8.3
 
 * Fix issue with `rnorm()` running on a GPU (device code).
+* Fix issue with unaligned shared copy in CUDA code.
 
 # dust 0.8.2
 

--- a/inst/include/dust/dust.hpp
+++ b/inst/include/dust/dust.hpp
@@ -173,8 +173,8 @@ public:
       align_padding(_device_data.n_shared_int * sizeof(int), sizeof(real_t))
       / sizeof(int);
     size_t shared_size_bytes =
-      (n_shared_int_effective * sizeof(int) +
-       _device_data.n_shared_real * sizeof(real_t);
+      n_shared_int_effective * sizeof(int) +
+      _device_data.n_shared_real * sizeof(real_t);
     if (_n_particles_each < warp_size || shared_size_bytes > _shared_size) {
       // If not enough particles per pars to make a whole block use
       // shared, or if shared_t too big for L1, turn it off, and run

--- a/inst/include/dust/dust.hpp
+++ b/inst/include/dust/dust.hpp
@@ -169,9 +169,12 @@ public:
     size_t blockSize = 128;
     size_t blockCount;
     bool use_shared_L1 = true;
+    size_t n_shared_int_effective = _device_data.n_shared_int +
+      align_padding(_device_data.n_shared_int * sizeof(int), sizeof(real_t))
+      / sizeof(int);
     size_t shared_size_bytes =
-      _device_data.n_shared_int * n_pars_effective() * sizeof(int) +
-      _device_data.n_shared_real * n_pars_effective() * sizeof(real_t);
+      (n_shared_int_effective * sizeof(int) +
+       _device_data.n_shared_real * sizeof(real_t);
     if (_n_particles_each < warp_size || shared_size_bytes > _shared_size) {
       // If not enough particles per pars to make a whole block use
       // shared, or if shared_t too big for L1, turn it off, and run

--- a/inst/include/dust/dust.hpp
+++ b/inst/include/dust/dust.hpp
@@ -170,10 +170,8 @@ public:
     size_t blockCount;
     bool use_shared_L1 = true;
     size_t n_shared_int_effective = _device_data.n_shared_int +
-      align_padding(_device_data.n_shared_int * sizeof(int), sizeof(real_t))
-      / sizeof(int);
-    size_t shared_size_bytes =
-      n_shared_int_effective * sizeof(int) +
+      dust::utils::align_padding(_device_data.n_shared_int * sizeof(int), sizeof(real_t)) / sizeof(int);
+    size_t shared_size_bytes = n_shared_int_effective * sizeof(int) +
       _device_data.n_shared_real * sizeof(real_t);
     if (_n_particles_each < warp_size || shared_size_bytes > _shared_size) {
       // If not enough particles per pars to make a whole block use

--- a/inst/include/dust/kernels.hpp
+++ b/inst/include/dust/kernels.hpp
@@ -64,6 +64,8 @@ KERNEL void run_particles(size_t step_start,
   // into __shared__ L1
   extern __shared__ int shared_block[];
   auto block = cooperative_groups::this_thread_block();
+  static_assert(sizeof(real_t) >= sizeof(int),
+                "real_t and int shared memory not alignable");
   if (use_shared_L1) {
     int * shared_block_int = shared_block;
     shared_mem_cpy(block, shared_block_int, p_shared_int, n_shared_int);
@@ -74,7 +76,6 @@ KERNEL void run_particles(size_t step_start,
     // Furthermore, writing must be aligned to the word length (may be an issue
     // with int and real, as odd n_shared_int leaves pointer in the middle of an
     // 8-byte word)
-    assert(sizeof(real_t) >= sizeof(int));
     size_t real_ptr_start = n_shared_int +
       dust::utils::align_padding(n_shared_int * sizeof(int), sizeof(real_t)) / sizeof(int);
     real_t * shared_block_real = (real_t*)&shared_block[real_ptr_start];

--- a/inst/include/dust/kernels.hpp
+++ b/inst/include/dust/kernels.hpp
@@ -2,6 +2,7 @@
 #define DUST_KERNELS_HPP
 
 #include <assert.h>
+#include <dust/utils.h>
 
 // This is the main model update, will be defined by the model code
 // (see inst/examples/variable.cpp for an example)

--- a/inst/include/dust/kernels.hpp
+++ b/inst/include/dust/kernels.hpp
@@ -76,7 +76,7 @@ KERNEL void run_particles(size_t step_start,
     // 8-byte word)
     assert(sizeof(real_t) > sizeof(int));
     size_t real_ptr_start = n_shared_int +
-      align_padding(n_shared_int * sizeof(int), sizeof(real_t)) / sizeof(int);
+      dust::utils::align_padding(n_shared_int * sizeof(int), sizeof(real_t)) / sizeof(int);
     real_t * shared_block_real = (real_t*)&shared_block[real_ptr_start];
     shared_mem_cpy(block, shared_block_real, p_shared_real, n_shared_real);
     p_shared_real = shared_block_real;

--- a/inst/include/dust/kernels.hpp
+++ b/inst/include/dust/kernels.hpp
@@ -1,6 +1,8 @@
 #ifndef DUST_KERNELS_HPP
 #define DUST_KERNELS_HPP
 
+#include <assert.h>
+
 // This is the main model update, will be defined by the model code
 // (see inst/examples/variable.cpp for an example)
 template <typename T>
@@ -68,7 +70,13 @@ KERNEL void run_particles(size_t step_start,
 
     // Must only have a single __shared__ definition, cast to use different
     // types within it
-    real_t * shared_block_real = (real_t*)&shared_block[n_shared_int];
+    // Furthermore, writing must be aligned to the word length (may be an issue
+    // with int and real, as odd n_shared_int leaves pointer in the middle of an
+    // 8-byte word)
+    assert(sizeof(real_t) > sizeof(int));
+    size_t real_ptr_start = n_shared_int +
+      align_padding(n_shared_int * sizeof(int), sizeof(real_t)) / sizeof(int);
+    real_t * shared_block_real = (real_t*)&shared_block[real_ptr_start];
     shared_mem_cpy(block, shared_block_real, p_shared_real, n_shared_real);
     p_shared_real = shared_block_real;
 

--- a/inst/include/dust/kernels.hpp
+++ b/inst/include/dust/kernels.hpp
@@ -2,7 +2,7 @@
 #define DUST_KERNELS_HPP
 
 #include <assert.h>
-#include <dust/utils.h>
+#include <dust/utils.hpp>
 
 // This is the main model update, will be defined by the model code
 // (see inst/examples/variable.cpp for an example)

--- a/inst/include/dust/kernels.hpp
+++ b/inst/include/dust/kernels.hpp
@@ -74,7 +74,7 @@ KERNEL void run_particles(size_t step_start,
     // Furthermore, writing must be aligned to the word length (may be an issue
     // with int and real, as odd n_shared_int leaves pointer in the middle of an
     // 8-byte word)
-    assert(sizeof(real_t) > sizeof(int));
+    assert(sizeof(real_t) >= sizeof(int));
     size_t real_ptr_start = n_shared_int +
       dust::utils::align_padding(n_shared_int * sizeof(int), sizeof(real_t)) / sizeof(int);
     real_t * shared_block_real = (real_t*)&shared_block[real_ptr_start];

--- a/inst/include/dust/utils.hpp
+++ b/inst/include/dust/utils.hpp
@@ -36,21 +36,21 @@ size_t stride_copy(T dest, const std::vector<U>& src, size_t at,
 
 #ifdef __NVCC__
 template <typename T>
-T epsilon_nvcc();
+HOSTDEVICE T epsilon_nvcc();
 
 template <>
-inline float epsilon_nvcc() {
+inline HOSTDEVICE float epsilon_nvcc() {
   return FLT_EPSILON;
 }
 
 template <>
-inline double epsilon_nvcc() {
+inline HOSTDEVICE double epsilon_nvcc() {
   return DBL_EPSILON;
 }
 #endif
 
 template <typename T>
-T epsilon() {
+HOSTDEVICE T epsilon() {
 #ifdef __NVCC__
   return epsilon_nvcc<T>();
 #else

--- a/inst/include/dust/utils.hpp
+++ b/inst/include/dust/utils.hpp
@@ -34,6 +34,10 @@ size_t stride_copy(T dest, const std::vector<U>& src, size_t at,
   return at;
 }
 
+inline HOSTDEVICE size_t align_padding(const size_t offset, const size_t align) {
+  return offset % align ? align - offset % align : 0));
+}
+
 #ifdef __NVCC__
 template <typename T>
 HOSTDEVICE T epsilon_nvcc();

--- a/inst/include/dust/utils.hpp
+++ b/inst/include/dust/utils.hpp
@@ -35,7 +35,8 @@ size_t stride_copy(T dest, const std::vector<U>& src, size_t at,
 }
 
 inline HOSTDEVICE size_t align_padding(const size_t offset, const size_t align) {
-  return offset % align ? align - offset % align : 0));
+  size_t remainder = offset % align;
+  return remainder ? align - remainder : 0;
 }
 
 #ifdef __NVCC__

--- a/inst/include/dust/utils.hpp
+++ b/inst/include/dust/utils.hpp
@@ -51,7 +51,7 @@ inline HOSTDEVICE double epsilon_nvcc() {
 
 template <typename T>
 HOSTDEVICE T epsilon() {
-#ifdef __NVCC__
+#ifdef __CUDA_ARCH__
   return epsilon_nvcc<T>();
 #else
   return std::numeric_limits<T>::epsilon();

--- a/inst/include/dust/utils.hpp
+++ b/inst/include/dust/utils.hpp
@@ -34,8 +34,9 @@ size_t stride_copy(T dest, const std::vector<U>& src, size_t at,
   return at;
 }
 
-inline HOSTDEVICE size_t align_padding(const size_t offset, const size_t align) {
-  size_t remainder = offset % align;
+template <typename T, typename U = T>
+inline HOSTDEVICE T align_padding(const T offset, const U align) {
+  T remainder = offset % align;
   return remainder ? align - remainder : 0;
 }
 

--- a/inst/include/dust/utils.hpp
+++ b/inst/include/dust/utils.hpp
@@ -39,12 +39,12 @@ template <typename T>
 HOSTDEVICE T epsilon_nvcc();
 
 template <>
-inline HOSTDEVICE float epsilon_nvcc() {
+inline DEVICE float epsilon_nvcc() {
   return FLT_EPSILON;
 }
 
 template <>
-inline HOSTDEVICE double epsilon_nvcc() {
+inline DEVICE double epsilon_nvcc() {
   return DBL_EPSILON;
 }
 #endif


### PR DESCRIPTION
Fixes two issues:

1. Numeric limits helper functions were not being compiled for use in device code (and compiler error likely suppressed with `__nv_exec_check_disable__`)

For posterity:
Run the kernel, get 'unspecified launch failure'. 
Run in the debugger, end up in CUDBG_ERROR_UNKNOWN_FUNCTION. 
Debugger also craps out because I think because the program counter gets set to 0. [I think the reason is because it is trying to call a branch to a function which has not been compiled (hence PC = 0)]
Specifically, this is epsilon() which is compiled as a host function only.
The fix is to add HOSTDEVICE to all of the numeric limits functions

2. Shared memory copies could be misaligned when `real_t = double` and `n_shared_int % 2 = 1` (address of real_t ptr is a multiple of 4 but not 8).