### PR TITLE
Tidy up profile start/stop

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dust
 Title: Iterate Multiple Realisations of Stochastic Models
-Version: 0.8.5
+Version: 0.8.6
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("John", "Lees", role = "aut"),

--- a/R/cuda.R
+++ b/R/cuda.R
@@ -293,7 +293,8 @@ cuda_options <- function(info, debug, profile, fast_math) {
     nvcc_flags <- "-O2"
   }
   if (profile) {
-    nvcc_flags <- paste(nvcc_flags, "-pg --generate-line-info")
+    nvcc_flags <- paste(nvcc_flags, "-pg --generate-line-info",
+                        "-DDUST_ENABLE_CUDA_PROFILER")
   }
   if (fast_math) {
     nvcc_flags <- paste(nvcc_flags, "--use_fast_math")

--- a/R/cuda.R
+++ b/R/cuda.R
@@ -117,6 +117,13 @@ dust_cuda_configuration <- function(path_cuda_lib = NULL,
 ##'   docs](https://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/index.html)
 ##'   for more details.
 ##'
+##' @param flags Optional extra arguments to pass to nvcc. These
+##'   options will not be passed to your normal C++ compiler, nor the
+##'   linker (for that use R's user Makevars system). This can be used
+##'   to do things like tune the maximum number of registers
+##'   (`--maxregcount=x`). If not `NULL`, this must be a character
+##'   vector, which will be concatenated with spaces between options.
+##'
 ##' @return An object of type `cuda_options`, which is subject to
 ##'   change, but can be passed into `dust`
 ##'
@@ -126,12 +133,12 @@ dust_cuda_configuration <- function(path_cuda_lib = NULL,
 ##'   dust::dust_cuda_options(),
 ##'   error = function(e) NULL)
 dust_cuda_options <- function(..., debug = FALSE, profile = FALSE,
-                              fast_math = FALSE) {
+                              fast_math = FALSE, flags = NULL) {
   info <- dust_cuda_configuration(...)
   if (!info$has_cuda) {
     stop("cuda not supported on this machine")
   }
-  cuda_options(info, debug, profile, fast_math)
+  cuda_options(info, debug, profile, fast_math, flags)
 }
 
 
@@ -286,7 +293,7 @@ cuda_install_cub <- function(path, version = "1.9.10", quiet = FALSE) {
 }
 
 
-cuda_options <- function(info, debug, profile, fast_math) {
+cuda_options <- function(info, debug, profile, fast_math, flags) {
   if (debug) {
     nvcc_flags <- "-g -G -O0"
   } else {
@@ -298,6 +305,9 @@ cuda_options <- function(info, debug, profile, fast_math) {
   }
   if (fast_math) {
     nvcc_flags <- paste(nvcc_flags, "--use_fast_math")
+  }
+  if (!is.null(flags)) {
+    nvcc_flags <- paste(nvcc_flags, paste(flags, collapse = " "))
   }
 
   gencode <- paste(

--- a/R/cuda.R
+++ b/R/cuda.R
@@ -121,7 +121,7 @@ dust_cuda_configuration <- function(path_cuda_lib = NULL,
 ##'   options will not be passed to your normal C++ compiler, nor the
 ##'   linker (for that use R's user Makevars system). This can be used
 ##'   to do things like tune the maximum number of registers
-##'   (`--maxregcount=x`). If not `NULL`, this must be a character
+##'   (`--maxrregcount x`). If not `NULL`, this must be a character
 ##'   vector, which will be concatenated with spaces between options.
 ##'
 ##' @return An object of type `cuda_options`, which is subject to

--- a/inst/include/dust/cuda.cuh
+++ b/inst/include/dust/cuda.cuh
@@ -56,11 +56,13 @@ DEVICE void shared_mem_wait(cooperative_groups::thread_block& block) {
 #endif
 }
 
+
 #else
 #define DEVICE
 #define HOST
 #define HOSTDEVICE
 #define KERNEL
+#undef DUST_CUDA_ENABLE_PROFILER
 #define __nv_exec_check_disable__
 #endif
 

--- a/inst/include/dust/cuda_call.cuh
+++ b/inst/include/dust/cuda_call.cuh
@@ -18,7 +18,9 @@ static void throw_cuda_error(const char *file, int line, cudaError_t status) {
     msg << file << "(" << line << ") CUDA Error Occurred:\n" <<
       cudaGetErrorString(status);
   }
+#ifdef DUST_ENABLE_CUDA_PROFILER
   cudaProfilerStop();
+#endif
   throw std::runtime_error(msg.str());
 }
 

--- a/inst/include/dust/dust.hpp
+++ b/inst/include/dust/dust.hpp
@@ -73,8 +73,10 @@ public:
     }
   }
 
-// This could be removed/commented out eventually
-#ifdef __NVCC__
+  // We only need a destructor when running with cuda profiling; don't
+  // include ond otherwise because we don't actually follow the rule
+  // of 3/5/0
+#ifdef DUST_ENABLE_CUDA_PROFILER
   ~Dust() {
     CUDA_CALL_NOTHROW(cudaProfilerStop());
   }
@@ -611,7 +613,9 @@ private:
                                      device_id));
     _shared_size = static_cast<size_t>(shared_size);
 
+#ifdef DUST_ENABLE_CUDA_PROFILER
     CUDA_CALL(cudaProfilerStart());
+#endif
 #endif
   }
 

--- a/man/dust_cuda_options.Rd
+++ b/man/dust_cuda_options.Rd
@@ -29,7 +29,7 @@ for more details.}
 options will not be passed to your normal C++ compiler, nor the
 linker (for that use R's user Makevars system). This can be used
 to do things like tune the maximum number of registers
-(\code{--maxregcount=x}). If not \code{NULL}, this must be a character
+(\verb{--maxrregcount x}). If not \code{NULL}, this must be a character
 vector, which will be concatenated with spaces between options.}
 }
 \value{

--- a/man/dust_cuda_options.Rd
+++ b/man/dust_cuda_options.Rd
@@ -4,7 +4,13 @@
 \alias{dust_cuda_options}
 \title{Create CUDA options}
 \usage{
-dust_cuda_options(..., debug = FALSE, profile = FALSE, fast_math = FALSE)
+dust_cuda_options(
+  ...,
+  debug = FALSE,
+  profile = FALSE,
+  fast_math = FALSE,
+  flags = NULL
+)
 }
 \arguments{
 \item{...}{Arguments passed to \link{dust_cuda_configuration}}
@@ -18,6 +24,13 @@ dust_cuda_options(..., debug = FALSE, profile = FALSE, fast_math = FALSE)
 maths", which lets the optimiser enable optimisations that break
 IEEE compliance and disables some error checking (see \href{https://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/index.html}{the CUDA docs}
 for more details.}
+
+\item{flags}{Optional extra arguments to pass to nvcc. These
+options will not be passed to your normal C++ compiler, nor the
+linker (for that use R's user Makevars system). This can be used
+to do things like tune the maximum number of registers
+(\code{--maxregcount=x}). If not \code{NULL}, this must be a character
+vector, which will be concatenated with spaces between options.}
 }
 \value{
 An object of type \code{cuda_options}, which is subject to

--- a/tests/testthat/test-gpu.R
+++ b/tests/testthat/test-gpu.R
@@ -249,7 +249,8 @@ test_that("Set the cuda options", {
 
   expect_mapequal(
     cuda_options(info, TRUE, TRUE, FALSE)$flags,
-    list(nvcc_flags = "-g -G -O0 -pg --generate-line-info",
+    list(nvcc_flags = paste("-g -G -O0 -pg --generate-line-info",
+                            "-DDUST_ENABLE_CUDA_PROFILER"),
          gencode = "-gencode=arch=compute_75,code=sm_75",
          cub_include = "",
          lib_flags = ""))


### PR DESCRIPTION
Quite a small quality of life improvement, mostly I like this because it removes the destructor.

Also makes the nvcc options fully configurable - we could theoretically remove the fast math one with this in, but I think that'll be fairly popular

Fixes #197 