### PR TITLE
Short circuit path on rpois

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dust
 Title: Iterate Multiple Realisations of Stochastic Models
-Version: 0.8.9
+Version: 0.8.10
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("John", "Lees", role = "aut"),

--- a/inst/include/dust/distr/poisson.hpp
+++ b/inst/include/dust/distr/poisson.hpp
@@ -10,7 +10,9 @@ template <typename real_t>
 int rpois(rng_state_t<real_t>& rng_state,
           typename rng_state_t<real_t>::real_t lambda) {
   int x = 0;
-  if (lambda < 10) {
+  if (lambda == 0) {
+    // do nothing, but leave this branch in to help the GPU
+  } else if (lambda < 10) {
     // Knuth's algorithm for generating Poisson random variates.
     // Given a Poisson process, the time between events is exponentially
     // distributed. If we have a Poisson process with rate lambda, then,

--- a/tests/testthat/test-rng.R
+++ b/tests/testthat/test-rng.R
@@ -219,6 +219,15 @@ test_that("Big poisson numbers", {
 })
 
 
+test_that("Short circuit exit does not update rng state", {
+  rng <- dust_rng$new(1, 1)
+  s <- rng$state()
+  ans <- rng$rpois(100, 0)
+  expect_equal(ans, rep(0, 100))
+  expect_identical(rng$state(), s)
+})
+
+
 test_that("norm_rand agrees with rnorm", {
   n <- 100000
   ans <- dust_rng$new(2, 1)$norm_rand(n)


### PR DESCRIPTION
As noted by @RaphaelS1, we don't do a short-circuit path for rpois, unlike rbinom.

Fixes #211 