### PR TITLE
Allow running all rng functions with floats

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dust
 Title: Iterate Multiple Realisations of Stochastic Models
-Version: 0.8.11
+Version: 0.8.12
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("John", "Lees", role = "aut"),

--- a/R/cpp11.R
+++ b/R/cpp11.R
@@ -20,56 +20,48 @@ dust_dpois <- function(x, lambda, log) {
   .Call(`_dust_dust_dpois`, x, lambda, log)
 }
 
-dust_rng_alloc <- function(r_seed, n_generators) {
-  .Call(`_dust_dust_rng_alloc`, r_seed, n_generators)
+dust_rng_alloc <- function(r_seed, n_generators, is_float) {
+  .Call(`_dust_dust_rng_alloc`, r_seed, n_generators, is_float)
 }
 
-dust_rng_size <- function(ptr) {
-  .Call(`_dust_dust_rng_size`, ptr)
+dust_rng_jump <- function(ptr, is_float) {
+  invisible(.Call(`_dust_dust_rng_jump`, ptr, is_float))
 }
 
-dust_rng_jump <- function(ptr) {
-  invisible(.Call(`_dust_dust_rng_jump`, ptr))
+dust_rng_long_jump <- function(ptr, is_float) {
+  invisible(.Call(`_dust_dust_rng_long_jump`, ptr, is_float))
 }
 
-dust_rng_long_jump <- function(ptr) {
-  invisible(.Call(`_dust_dust_rng_long_jump`, ptr))
+dust_rng_unif_rand <- function(ptr, n, is_float) {
+  .Call(`_dust_dust_rng_unif_rand`, ptr, n, is_float)
 }
 
-dust_rng_unif_rand <- function(ptr, n) {
-  .Call(`_dust_dust_rng_unif_rand`, ptr, n)
+dust_rng_norm_rand <- function(ptr, n, is_float) {
+  .Call(`_dust_dust_rng_norm_rand`, ptr, n, is_float)
 }
 
-dust_rng_norm_rand <- function(ptr, n) {
-  .Call(`_dust_dust_rng_norm_rand`, ptr, n)
+dust_rng_runif <- function(ptr, n, r_min, r_max, is_float) {
+  .Call(`_dust_dust_rng_runif`, ptr, n, r_min, r_max, is_float)
 }
 
-dust_rng_runif <- function(ptr, n, r_min, r_max) {
-  .Call(`_dust_dust_rng_runif`, ptr, n, r_min, r_max)
+dust_rng_rexp <- function(ptr, n, r_rate, is_float) {
+  .Call(`_dust_dust_rng_rexp`, ptr, n, r_rate, is_float)
 }
 
-dust_rng_rexp <- function(ptr, n, r_rate) {
-  .Call(`_dust_dust_rng_rexp`, ptr, n, r_rate)
+dust_rng_rnorm <- function(ptr, n, r_mean, r_sd, is_float) {
+  .Call(`_dust_dust_rng_rnorm`, ptr, n, r_mean, r_sd, is_float)
 }
 
-dust_rng_rnorm <- function(ptr, n, r_mean, r_sd) {
-  .Call(`_dust_dust_rng_rnorm`, ptr, n, r_mean, r_sd)
+dust_rng_rbinom <- function(ptr, n, r_size, r_prob, is_float) {
+  .Call(`_dust_dust_rng_rbinom`, ptr, n, r_size, r_prob, is_float)
 }
 
-dust_rng_rbinom <- function(ptr, n, r_size, r_prob) {
-  .Call(`_dust_dust_rng_rbinom`, ptr, n, r_size, r_prob)
+dust_rng_rpois <- function(ptr, n, r_lambda, is_float) {
+  .Call(`_dust_dust_rng_rpois`, ptr, n, r_lambda, is_float)
 }
 
-dust_rng_rpois <- function(ptr, n, r_lambda) {
-  .Call(`_dust_dust_rng_rpois`, ptr, n, r_lambda)
-}
-
-dust_rng_state <- function(ptr) {
-  .Call(`_dust_dust_rng_state`, ptr)
-}
-
-test_rbinom_float <- function(r_seed, n_samples, size, p) {
-  .Call(`_dust_test_rbinom_float`, r_seed, n_samples, size, p)
+dust_rng_state <- function(ptr, is_float) {
+  .Call(`_dust_dust_rng_state`, ptr, is_float)
 }
 
 cpp_openmp_info <- function() {

--- a/R/rng.R
+++ b/R/rng.R
@@ -32,7 +32,8 @@ dust_rng <- R6::R6Class(
   private = list(
     ptr = NULL,
     n_generators = NULL,
-    float = NULL
+    float = NULL,
+    real_t = NULL
   ),
 
   public = list(
@@ -44,13 +45,18 @@ dust_rng <- R6::R6Class(
     ##'   function never runs in parallel, this is used to create a set of
     ##'   interleaved independent generators as dust would use in a model.
     ##'
-    ##' @param float Use `float` (rather than `double`) for the numbers.
-    ##'   This will have no (or negligible) impact on speed, but exists
-    ##'   to test the low-precision generators.
-    initialize = function(seed, n_generators = 1L, float = FALSE) {
-      private$ptr <- dust_rng_alloc(seed, n_generators, float)
+    ##' @param real_type The type of floating point number to use. Currently
+    ##'   only `float` and `double` are supported (with `double` being
+    ##'   the default). This will have no (or negligible) impact on speed,
+    ##'   but exists to test the low-precision generators.
+    initialize = function(seed, n_generators = 1L, real_type = "double") {
+      if (!(real_type %in% c("double", "float"))) {
+        stop("Invalid value for 'real_type': must be 'double' or 'float'")
+      }
+      private$float <- real_type == "float"
+      private$ptr <- dust_rng_alloc(seed, n_generators, private$float)
       private$n_generators <- n_generators
-      private$float <- float
+      private$real_t <- real_type
     },
 
     ##' @description Number of generators available
@@ -59,7 +65,7 @@ dust_rng <- R6::R6Class(
     },
 
     ##' @description Indicates the floating point type
-    real_t = function() {
+    real_type = function() {
       if (private$float) "float" else "double"
     },
 

--- a/inst/include/dust/distr/exponential.hpp
+++ b/inst/include/dust/distr/exponential.hpp
@@ -22,7 +22,8 @@ HOSTDEVICE real_t exp_rand(rng_state_t<real_t>& rng_state) {
 
 __nv_exec_check_disable__
 template <typename real_t>
-HOSTDEVICE real_t rexp(rng_state_t<real_t>& rng_state, real_t rate) {
+HOSTDEVICE real_t rexp(rng_state_t<real_t>& rng_state,
+                       typename rng_state_t<real_t>::real_t rate) {
   return exp_rand(rng_state) / rate;
 }
 

--- a/inst/include/dust/distr/normal.hpp
+++ b/inst/include/dust/distr/normal.hpp
@@ -30,8 +30,8 @@ HOSTDEVICE inline real_t box_muller(rng_state_t<real_t>& rng_state) {
 __nv_exec_check_disable__
 template <typename real_t>
 HOSTDEVICE real_t rnorm(rng_state_t<real_t>& rng_state,
-             typename rng_state_t<real_t>::real_t mean,
-             typename rng_state_t<real_t>::real_t sd) {
+                        typename rng_state_t<real_t>::real_t mean,
+                        typename rng_state_t<real_t>::real_t sd) {
   real_t z = box_muller<real_t>(rng_state);
   return z * sd + mean;
 }

--- a/inst/include/dust/interface_helpers.hpp
+++ b/inst/include/dust/interface_helpers.hpp
@@ -1,6 +1,8 @@
 #ifndef DUST_INTERFACE_HELPERS_HPP
 #define DUST_INTERFACE_HELPERS_HPP
 
+#include <map>
+#include <cpp11/strings.hpp>
 #include <dust/device_info.hpp>
 
 namespace dust {

--- a/man/dust_rng.Rd
+++ b/man/dust_rng.Rd
@@ -34,6 +34,7 @@ rng$rpois(5, 2)
 \itemize{
 \item \href{#method-new}{\code{dust_rng$new()}}
 \item \href{#method-size}{\code{dust_rng$size()}}
+\item \href{#method-real_t}{\code{dust_rng$real_t()}}
 \item \href{#method-jump}{\code{dust_rng$jump()}}
 \item \href{#method-long_jump}{\code{dust_rng$long_jump()}}
 \item \href{#method-unif_rand}{\code{dust_rng$unif_rand()}}
@@ -52,7 +53,7 @@ rng$rpois(5, 2)
 \subsection{Method \code{new()}}{
 Create a \code{dust_rng} object
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{dust_rng$new(seed, n_generators = 1L)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{dust_rng$new(seed, n_generators = 1L, float = FALSE)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -63,6 +64,10 @@ Create a \code{dust_rng} object
 \item{\code{n_generators}}{The number of generators to use. While this
 function never runs in parallel, this is used to create a set of
 interleaved independent generators as dust would use in a model.}
+
+\item{\code{float}}{Use \code{float} (rather than \code{double}) for the numbers.
+This will have no (or negligible) impact on speed, but exists
+to test the low-precision generators.}
 }
 \if{html}{\out{</div>}}
 }
@@ -74,6 +79,16 @@ interleaved independent generators as dust would use in a model.}
 Number of generators available
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{dust_rng$size()}\if{html}{\out{</div>}}
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-real_t"></a>}}
+\if{latex}{\out{\hypertarget{method-real_t}{}}}
+\subsection{Method \code{real_t()}}{
+Indicates the floating point type
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{dust_rng$real_t()}\if{html}{\out{</div>}}
 }
 
 }

--- a/man/dust_rng.Rd
+++ b/man/dust_rng.Rd
@@ -34,7 +34,7 @@ rng$rpois(5, 2)
 \itemize{
 \item \href{#method-new}{\code{dust_rng$new()}}
 \item \href{#method-size}{\code{dust_rng$size()}}
-\item \href{#method-real_t}{\code{dust_rng$real_t()}}
+\item \href{#method-real_type}{\code{dust_rng$real_type()}}
 \item \href{#method-jump}{\code{dust_rng$jump()}}
 \item \href{#method-long_jump}{\code{dust_rng$long_jump()}}
 \item \href{#method-unif_rand}{\code{dust_rng$unif_rand()}}
@@ -53,7 +53,7 @@ rng$rpois(5, 2)
 \subsection{Method \code{new()}}{
 Create a \code{dust_rng} object
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{dust_rng$new(seed, n_generators = 1L, float = FALSE)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{dust_rng$new(seed, n_generators = 1L, real_type = "double")}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -65,9 +65,10 @@ Create a \code{dust_rng} object
 function never runs in parallel, this is used to create a set of
 interleaved independent generators as dust would use in a model.}
 
-\item{\code{float}}{Use \code{float} (rather than \code{double}) for the numbers.
-This will have no (or negligible) impact on speed, but exists
-to test the low-precision generators.}
+\item{\code{real_type}}{The type of floating point number to use. Currently
+only \code{float} and \code{double} are supported (with \code{double} being
+the default). This will have no (or negligible) impact on speed,
+but exists to test the low-precision generators.}
 }
 \if{html}{\out{</div>}}
 }
@@ -83,12 +84,12 @@ Number of generators available
 
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-real_t"></a>}}
-\if{latex}{\out{\hypertarget{method-real_t}{}}}
-\subsection{Method \code{real_t()}}{
+\if{html}{\out{<a id="method-real_type"></a>}}
+\if{latex}{\out{\hypertarget{method-real_type}{}}}
+\subsection{Method \code{real_type()}}{
 Indicates the floating point type
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{dust_rng$real_t()}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{dust_rng$real_type()}\if{html}{\out{</div>}}
 }
 
 }

--- a/src/cpp11.cpp
+++ b/src/cpp11.cpp
@@ -40,96 +40,82 @@ extern "C" SEXP _dust_dust_dpois(SEXP x, SEXP lambda, SEXP log) {
   END_CPP11
 }
 // dust_rng.cpp
-SEXP dust_rng_alloc(cpp11::sexp r_seed, int n_generators);
-extern "C" SEXP _dust_dust_rng_alloc(SEXP r_seed, SEXP n_generators) {
+SEXP dust_rng_alloc(cpp11::sexp r_seed, int n_generators, bool is_float);
+extern "C" SEXP _dust_dust_rng_alloc(SEXP r_seed, SEXP n_generators, SEXP is_float) {
   BEGIN_CPP11
-    return cpp11::as_sexp(dust_rng_alloc(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_seed), cpp11::as_cpp<cpp11::decay_t<int>>(n_generators)));
+    return cpp11::as_sexp(dust_rng_alloc(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_seed), cpp11::as_cpp<cpp11::decay_t<int>>(n_generators), cpp11::as_cpp<cpp11::decay_t<bool>>(is_float)));
   END_CPP11
 }
 // dust_rng.cpp
-int dust_rng_size(SEXP ptr);
-extern "C" SEXP _dust_dust_rng_size(SEXP ptr) {
+void dust_rng_jump(SEXP ptr, bool is_float);
+extern "C" SEXP _dust_dust_rng_jump(SEXP ptr, SEXP is_float) {
   BEGIN_CPP11
-    return cpp11::as_sexp(dust_rng_size(cpp11::as_cpp<cpp11::decay_t<SEXP>>(ptr)));
-  END_CPP11
-}
-// dust_rng.cpp
-void dust_rng_jump(SEXP ptr);
-extern "C" SEXP _dust_dust_rng_jump(SEXP ptr) {
-  BEGIN_CPP11
-    dust_rng_jump(cpp11::as_cpp<cpp11::decay_t<SEXP>>(ptr));
+    dust_rng_jump(cpp11::as_cpp<cpp11::decay_t<SEXP>>(ptr), cpp11::as_cpp<cpp11::decay_t<bool>>(is_float));
     return R_NilValue;
   END_CPP11
 }
 // dust_rng.cpp
-void dust_rng_long_jump(SEXP ptr);
-extern "C" SEXP _dust_dust_rng_long_jump(SEXP ptr) {
+void dust_rng_long_jump(SEXP ptr, bool is_float);
+extern "C" SEXP _dust_dust_rng_long_jump(SEXP ptr, SEXP is_float) {
   BEGIN_CPP11
-    dust_rng_long_jump(cpp11::as_cpp<cpp11::decay_t<SEXP>>(ptr));
+    dust_rng_long_jump(cpp11::as_cpp<cpp11::decay_t<SEXP>>(ptr), cpp11::as_cpp<cpp11::decay_t<bool>>(is_float));
     return R_NilValue;
   END_CPP11
 }
 // dust_rng.cpp
-cpp11::writable::doubles dust_rng_unif_rand(SEXP ptr, int n);
-extern "C" SEXP _dust_dust_rng_unif_rand(SEXP ptr, SEXP n) {
+cpp11::writable::doubles dust_rng_unif_rand(SEXP ptr, int n, bool is_float);
+extern "C" SEXP _dust_dust_rng_unif_rand(SEXP ptr, SEXP n, SEXP is_float) {
   BEGIN_CPP11
-    return cpp11::as_sexp(dust_rng_unif_rand(cpp11::as_cpp<cpp11::decay_t<SEXP>>(ptr), cpp11::as_cpp<cpp11::decay_t<int>>(n)));
+    return cpp11::as_sexp(dust_rng_unif_rand(cpp11::as_cpp<cpp11::decay_t<SEXP>>(ptr), cpp11::as_cpp<cpp11::decay_t<int>>(n), cpp11::as_cpp<cpp11::decay_t<bool>>(is_float)));
   END_CPP11
 }
 // dust_rng.cpp
-cpp11::writable::doubles dust_rng_norm_rand(SEXP ptr, int n);
-extern "C" SEXP _dust_dust_rng_norm_rand(SEXP ptr, SEXP n) {
+cpp11::writable::doubles dust_rng_norm_rand(SEXP ptr, int n, bool is_float);
+extern "C" SEXP _dust_dust_rng_norm_rand(SEXP ptr, SEXP n, SEXP is_float) {
   BEGIN_CPP11
-    return cpp11::as_sexp(dust_rng_norm_rand(cpp11::as_cpp<cpp11::decay_t<SEXP>>(ptr), cpp11::as_cpp<cpp11::decay_t<int>>(n)));
+    return cpp11::as_sexp(dust_rng_norm_rand(cpp11::as_cpp<cpp11::decay_t<SEXP>>(ptr), cpp11::as_cpp<cpp11::decay_t<int>>(n), cpp11::as_cpp<cpp11::decay_t<bool>>(is_float)));
   END_CPP11
 }
 // dust_rng.cpp
-cpp11::writable::doubles dust_rng_runif(SEXP ptr, int n, cpp11::doubles r_min, cpp11::doubles r_max);
-extern "C" SEXP _dust_dust_rng_runif(SEXP ptr, SEXP n, SEXP r_min, SEXP r_max) {
+cpp11::writable::doubles dust_rng_runif(SEXP ptr, int n, cpp11::doubles r_min, cpp11::doubles r_max, bool is_float);
+extern "C" SEXP _dust_dust_rng_runif(SEXP ptr, SEXP n, SEXP r_min, SEXP r_max, SEXP is_float) {
   BEGIN_CPP11
-    return cpp11::as_sexp(dust_rng_runif(cpp11::as_cpp<cpp11::decay_t<SEXP>>(ptr), cpp11::as_cpp<cpp11::decay_t<int>>(n), cpp11::as_cpp<cpp11::decay_t<cpp11::doubles>>(r_min), cpp11::as_cpp<cpp11::decay_t<cpp11::doubles>>(r_max)));
+    return cpp11::as_sexp(dust_rng_runif(cpp11::as_cpp<cpp11::decay_t<SEXP>>(ptr), cpp11::as_cpp<cpp11::decay_t<int>>(n), cpp11::as_cpp<cpp11::decay_t<cpp11::doubles>>(r_min), cpp11::as_cpp<cpp11::decay_t<cpp11::doubles>>(r_max), cpp11::as_cpp<cpp11::decay_t<bool>>(is_float)));
   END_CPP11
 }
 // dust_rng.cpp
-cpp11::writable::doubles dust_rng_rexp(SEXP ptr, int n, cpp11::doubles r_rate);
-extern "C" SEXP _dust_dust_rng_rexp(SEXP ptr, SEXP n, SEXP r_rate) {
+cpp11::writable::doubles dust_rng_rexp(SEXP ptr, int n, cpp11::doubles r_rate, bool is_float);
+extern "C" SEXP _dust_dust_rng_rexp(SEXP ptr, SEXP n, SEXP r_rate, SEXP is_float) {
   BEGIN_CPP11
-    return cpp11::as_sexp(dust_rng_rexp(cpp11::as_cpp<cpp11::decay_t<SEXP>>(ptr), cpp11::as_cpp<cpp11::decay_t<int>>(n), cpp11::as_cpp<cpp11::decay_t<cpp11::doubles>>(r_rate)));
+    return cpp11::as_sexp(dust_rng_rexp(cpp11::as_cpp<cpp11::decay_t<SEXP>>(ptr), cpp11::as_cpp<cpp11::decay_t<int>>(n), cpp11::as_cpp<cpp11::decay_t<cpp11::doubles>>(r_rate), cpp11::as_cpp<cpp11::decay_t<bool>>(is_float)));
   END_CPP11
 }
 // dust_rng.cpp
-cpp11::writable::doubles dust_rng_rnorm(SEXP ptr, int n, cpp11::doubles r_mean, cpp11::doubles r_sd);
-extern "C" SEXP _dust_dust_rng_rnorm(SEXP ptr, SEXP n, SEXP r_mean, SEXP r_sd) {
+cpp11::writable::doubles dust_rng_rnorm(SEXP ptr, int n, cpp11::doubles r_mean, cpp11::doubles r_sd, bool is_float);
+extern "C" SEXP _dust_dust_rng_rnorm(SEXP ptr, SEXP n, SEXP r_mean, SEXP r_sd, SEXP is_float) {
   BEGIN_CPP11
-    return cpp11::as_sexp(dust_rng_rnorm(cpp11::as_cpp<cpp11::decay_t<SEXP>>(ptr), cpp11::as_cpp<cpp11::decay_t<int>>(n), cpp11::as_cpp<cpp11::decay_t<cpp11::doubles>>(r_mean), cpp11::as_cpp<cpp11::decay_t<cpp11::doubles>>(r_sd)));
+    return cpp11::as_sexp(dust_rng_rnorm(cpp11::as_cpp<cpp11::decay_t<SEXP>>(ptr), cpp11::as_cpp<cpp11::decay_t<int>>(n), cpp11::as_cpp<cpp11::decay_t<cpp11::doubles>>(r_mean), cpp11::as_cpp<cpp11::decay_t<cpp11::doubles>>(r_sd), cpp11::as_cpp<cpp11::decay_t<bool>>(is_float)));
   END_CPP11
 }
 // dust_rng.cpp
-cpp11::writable::integers dust_rng_rbinom(SEXP ptr, int n, cpp11::integers r_size, cpp11::doubles r_prob);
-extern "C" SEXP _dust_dust_rng_rbinom(SEXP ptr, SEXP n, SEXP r_size, SEXP r_prob) {
+cpp11::writable::integers dust_rng_rbinom(SEXP ptr, int n, cpp11::sexp r_size, cpp11::doubles r_prob, bool is_float);
+extern "C" SEXP _dust_dust_rng_rbinom(SEXP ptr, SEXP n, SEXP r_size, SEXP r_prob, SEXP is_float) {
   BEGIN_CPP11
-    return cpp11::as_sexp(dust_rng_rbinom(cpp11::as_cpp<cpp11::decay_t<SEXP>>(ptr), cpp11::as_cpp<cpp11::decay_t<int>>(n), cpp11::as_cpp<cpp11::decay_t<cpp11::integers>>(r_size), cpp11::as_cpp<cpp11::decay_t<cpp11::doubles>>(r_prob)));
+    return cpp11::as_sexp(dust_rng_rbinom(cpp11::as_cpp<cpp11::decay_t<SEXP>>(ptr), cpp11::as_cpp<cpp11::decay_t<int>>(n), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_size), cpp11::as_cpp<cpp11::decay_t<cpp11::doubles>>(r_prob), cpp11::as_cpp<cpp11::decay_t<bool>>(is_float)));
   END_CPP11
 }
 // dust_rng.cpp
-cpp11::writable::integers dust_rng_rpois(SEXP ptr, int n, cpp11::doubles r_lambda);
-extern "C" SEXP _dust_dust_rng_rpois(SEXP ptr, SEXP n, SEXP r_lambda) {
+cpp11::writable::integers dust_rng_rpois(SEXP ptr, int n, cpp11::doubles r_lambda, bool is_float);
+extern "C" SEXP _dust_dust_rng_rpois(SEXP ptr, SEXP n, SEXP r_lambda, SEXP is_float) {
   BEGIN_CPP11
-    return cpp11::as_sexp(dust_rng_rpois(cpp11::as_cpp<cpp11::decay_t<SEXP>>(ptr), cpp11::as_cpp<cpp11::decay_t<int>>(n), cpp11::as_cpp<cpp11::decay_t<cpp11::doubles>>(r_lambda)));
+    return cpp11::as_sexp(dust_rng_rpois(cpp11::as_cpp<cpp11::decay_t<SEXP>>(ptr), cpp11::as_cpp<cpp11::decay_t<int>>(n), cpp11::as_cpp<cpp11::decay_t<cpp11::doubles>>(r_lambda), cpp11::as_cpp<cpp11::decay_t<bool>>(is_float)));
   END_CPP11
 }
 // dust_rng.cpp
-cpp11::writable::raws dust_rng_state(SEXP ptr);
-extern "C" SEXP _dust_dust_rng_state(SEXP ptr) {
+cpp11::writable::raws dust_rng_state(SEXP ptr, bool is_float);
+extern "C" SEXP _dust_dust_rng_state(SEXP ptr, SEXP is_float) {
   BEGIN_CPP11
-    return cpp11::as_sexp(dust_rng_state(cpp11::as_cpp<cpp11::decay_t<SEXP>>(ptr)));
-  END_CPP11
-}
-// dust_rng.cpp
-cpp11::sexp test_rbinom_float(cpp11::sexp r_seed, int n_samples, int size, double p);
-extern "C" SEXP _dust_test_rbinom_float(SEXP r_seed, SEXP n_samples, SEXP size, SEXP p) {
-  BEGIN_CPP11
-    return cpp11::as_sexp(test_rbinom_float(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_seed), cpp11::as_cpp<cpp11::decay_t<int>>(n_samples), cpp11::as_cpp<cpp11::decay_t<int>>(size), cpp11::as_cpp<cpp11::decay_t<double>>(p)));
+    return cpp11::as_sexp(dust_rng_state(cpp11::as_cpp<cpp11::decay_t<SEXP>>(ptr), cpp11::as_cpp<cpp11::decay_t<bool>>(is_float)));
   END_CPP11
 }
 // openmp.cpp
@@ -724,18 +710,17 @@ extern SEXP _dust_dust_dbinom(SEXP, SEXP, SEXP, SEXP);
 extern SEXP _dust_dust_dnbinom(SEXP, SEXP, SEXP, SEXP);
 extern SEXP _dust_dust_dnorm(SEXP, SEXP, SEXP, SEXP);
 extern SEXP _dust_dust_dpois(SEXP, SEXP, SEXP);
-extern SEXP _dust_dust_rng_alloc(SEXP, SEXP);
-extern SEXP _dust_dust_rng_jump(SEXP);
-extern SEXP _dust_dust_rng_long_jump(SEXP);
-extern SEXP _dust_dust_rng_norm_rand(SEXP, SEXP);
-extern SEXP _dust_dust_rng_rbinom(SEXP, SEXP, SEXP, SEXP);
-extern SEXP _dust_dust_rng_rexp(SEXP, SEXP, SEXP);
-extern SEXP _dust_dust_rng_rnorm(SEXP, SEXP, SEXP, SEXP);
-extern SEXP _dust_dust_rng_rpois(SEXP, SEXP, SEXP);
-extern SEXP _dust_dust_rng_runif(SEXP, SEXP, SEXP, SEXP);
-extern SEXP _dust_dust_rng_size(SEXP);
-extern SEXP _dust_dust_rng_state(SEXP);
-extern SEXP _dust_dust_rng_unif_rand(SEXP, SEXP);
+extern SEXP _dust_dust_rng_alloc(SEXP, SEXP, SEXP);
+extern SEXP _dust_dust_rng_jump(SEXP, SEXP);
+extern SEXP _dust_dust_rng_long_jump(SEXP, SEXP);
+extern SEXP _dust_dust_rng_norm_rand(SEXP, SEXP, SEXP);
+extern SEXP _dust_dust_rng_rbinom(SEXP, SEXP, SEXP, SEXP, SEXP);
+extern SEXP _dust_dust_rng_rexp(SEXP, SEXP, SEXP, SEXP);
+extern SEXP _dust_dust_rng_rnorm(SEXP, SEXP, SEXP, SEXP, SEXP);
+extern SEXP _dust_dust_rng_rpois(SEXP, SEXP, SEXP, SEXP);
+extern SEXP _dust_dust_rng_runif(SEXP, SEXP, SEXP, SEXP, SEXP);
+extern SEXP _dust_dust_rng_state(SEXP, SEXP);
+extern SEXP _dust_dust_rng_unif_rand(SEXP, SEXP, SEXP);
 extern SEXP _dust_dust_sir_alloc(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP _dust_dust_sir_capabilities();
 extern SEXP _dust_dust_sir_compare_data(SEXP);
@@ -816,7 +801,6 @@ extern SEXP _dust_dust_walk_set_state(SEXP, SEXP, SEXP);
 extern SEXP _dust_dust_walk_simulate(SEXP, SEXP);
 extern SEXP _dust_dust_walk_state(SEXP, SEXP);
 extern SEXP _dust_dust_walk_step(SEXP);
-extern SEXP _dust_test_rbinom_float(SEXP, SEXP, SEXP, SEXP);
 
 static const R_CallMethodDef CallEntries[] = {
     {"_dust_cpp_openmp_info",               (DL_FUNC) &_dust_cpp_openmp_info,               0},
@@ -826,18 +810,17 @@ static const R_CallMethodDef CallEntries[] = {
     {"_dust_dust_dnbinom",                  (DL_FUNC) &_dust_dust_dnbinom,                  4},
     {"_dust_dust_dnorm",                    (DL_FUNC) &_dust_dust_dnorm,                    4},
     {"_dust_dust_dpois",                    (DL_FUNC) &_dust_dust_dpois,                    3},
-    {"_dust_dust_rng_alloc",                (DL_FUNC) &_dust_dust_rng_alloc,                2},
-    {"_dust_dust_rng_jump",                 (DL_FUNC) &_dust_dust_rng_jump,                 1},
-    {"_dust_dust_rng_long_jump",            (DL_FUNC) &_dust_dust_rng_long_jump,            1},
-    {"_dust_dust_rng_norm_rand",            (DL_FUNC) &_dust_dust_rng_norm_rand,            2},
-    {"_dust_dust_rng_rbinom",               (DL_FUNC) &_dust_dust_rng_rbinom,               4},
-    {"_dust_dust_rng_rexp",                 (DL_FUNC) &_dust_dust_rng_rexp,                 3},
-    {"_dust_dust_rng_rnorm",                (DL_FUNC) &_dust_dust_rng_rnorm,                4},
-    {"_dust_dust_rng_rpois",                (DL_FUNC) &_dust_dust_rng_rpois,                3},
-    {"_dust_dust_rng_runif",                (DL_FUNC) &_dust_dust_rng_runif,                4},
-    {"_dust_dust_rng_size",                 (DL_FUNC) &_dust_dust_rng_size,                 1},
-    {"_dust_dust_rng_state",                (DL_FUNC) &_dust_dust_rng_state,                1},
-    {"_dust_dust_rng_unif_rand",            (DL_FUNC) &_dust_dust_rng_unif_rand,            2},
+    {"_dust_dust_rng_alloc",                (DL_FUNC) &_dust_dust_rng_alloc,                3},
+    {"_dust_dust_rng_jump",                 (DL_FUNC) &_dust_dust_rng_jump,                 2},
+    {"_dust_dust_rng_long_jump",            (DL_FUNC) &_dust_dust_rng_long_jump,            2},
+    {"_dust_dust_rng_norm_rand",            (DL_FUNC) &_dust_dust_rng_norm_rand,            3},
+    {"_dust_dust_rng_rbinom",               (DL_FUNC) &_dust_dust_rng_rbinom,               5},
+    {"_dust_dust_rng_rexp",                 (DL_FUNC) &_dust_dust_rng_rexp,                 4},
+    {"_dust_dust_rng_rnorm",                (DL_FUNC) &_dust_dust_rng_rnorm,                5},
+    {"_dust_dust_rng_rpois",                (DL_FUNC) &_dust_dust_rng_rpois,                4},
+    {"_dust_dust_rng_runif",                (DL_FUNC) &_dust_dust_rng_runif,                5},
+    {"_dust_dust_rng_state",                (DL_FUNC) &_dust_dust_rng_state,                2},
+    {"_dust_dust_rng_unif_rand",            (DL_FUNC) &_dust_dust_rng_unif_rand,            3},
     {"_dust_dust_sir_alloc",                (DL_FUNC) &_dust_dust_sir_alloc,                7},
     {"_dust_dust_sir_capabilities",         (DL_FUNC) &_dust_dust_sir_capabilities,         0},
     {"_dust_dust_sir_compare_data",         (DL_FUNC) &_dust_dust_sir_compare_data,         1},
@@ -918,7 +901,6 @@ static const R_CallMethodDef CallEntries[] = {
     {"_dust_dust_walk_simulate",            (DL_FUNC) &_dust_dust_walk_simulate,            2},
     {"_dust_dust_walk_state",               (DL_FUNC) &_dust_dust_walk_state,               2},
     {"_dust_dust_walk_step",                (DL_FUNC) &_dust_dust_walk_step,                1},
-    {"_dust_test_rbinom_float",             (DL_FUNC) &_dust_test_rbinom_float,             4},
     {NULL, NULL, 0}
 };
 }

--- a/tests/testthat/test-rng.R
+++ b/tests/testthat/test-rng.R
@@ -350,7 +350,8 @@ test_that("initialise parallel rng with binary state and drop", {
   rng10 <- dust_rng$new(seed, 10L)
   rng5 <- dust_rng$new(rng10$state(), 5L)
   expect_identical(rng5$state(), rng10$state()[seq_len(5 * 4 * 8)])
-  expect_identical(dust_rng$new(rng10$state(), 5L, TRUE)$state(), rng5$state())
+  expect_identical(dust_rng$new(rng10$state(), 5L, "float")$state(),
+                   rng5$state())
 })
 
 
@@ -361,7 +362,7 @@ test_that("require that raw vector is of sensible size", {
                "Expected raw vector of length as multiple of 32 for 'seed'")
   expect_error(dust_rng$new(raw(63), 1L),
                "Expected raw vector of length as multiple of 32 for 'seed'")
-  expect_error(dust_rng$new(raw(63), 1L, TRUE),
+  expect_error(dust_rng$new(raw(63), 1L, "float"),
                "Expected raw vector of length as multiple of 32 for 'seed'")
 })
 
@@ -373,8 +374,8 @@ test_that("initialise with NULL, generating a seed from R", {
   rng2 <- dust_rng$new(NULL, 1L)
   rng3 <- dust_rng$new(NULL, 1L)
   set.seed(1)
-  rng4 <- dust_rng$new(NULL, 1L, TRUE)
-  rng5 <- dust_rng$new(NULL, 1L, TRUE)
+  rng4 <- dust_rng$new(NULL, 1L, "float")
+  rng5 <- dust_rng$new(NULL, 1L, "float")
 
   expect_identical(rng2$state(), rng1$state())
   expect_false(identical(rng3$state(), rng2$state()))
@@ -392,7 +393,7 @@ test_that("can't create rng with silly things", {
     dust_rng$new(function(x) 2, 1L),
     "Invalid type for 'seed'")
   expect_error(
-    dust_rng$new(function(x) 2, 1L, TRUE),
+    dust_rng$new(function(x) 2, 1L, "float"),
     "Invalid type for 'seed'")
 })
 
@@ -430,8 +431,8 @@ test_that("binomial random numbers from floats have correct distribution", {
   m <- 100000
   n <- 958L
   p <- 0.004145
-  yf <- dust_rng$new(1, 1, TRUE)$rbinom(m, n, p)
-  yd <- dust_rng$new(1, 1, FALSE)$rbinom(m, n, p)
+  yf <- dust_rng$new(1, 1, "float")$rbinom(m, n, p)
+  yd <- dust_rng$new(1, 1, "double")$rbinom(m, n, p)
   expect_equal(mean(yf), mean(yd), tolerance = 1e-4)
   expect_equal(var(yf), var(yd), tolerance = 1e-3)
 })
@@ -441,15 +442,15 @@ test_that("binomial random numbers from floats have correct distribution", {
   m <- 100000
   n <- 100L
   p <- 0.1
-  yf <- dust_rng$new(1, 1, TRUE)$rbinom(m, n, p)
-  yd <- dust_rng$new(1, 1, FALSE)$rbinom(m, n, p)
+  yf <- dust_rng$new(1, 1, "float")$rbinom(m, n, p)
+  yd <- dust_rng$new(1, 1, "double")$rbinom(m, n, p)
   expect_equal(mean(yf), mean(yd), tolerance = 1e-4)
   expect_equal(var(yf), var(yd), tolerance = 1e-3)
 })
 
 
 test_that("float/double binom identical behaviour in corner cases", {
-  rng_f <- dust_rng$new(1, 1, TRUE)
+  rng_f <- dust_rng$new(1, 1, "float")
 
   ## Short circuiting does not advance rng:
   s <- rng_f$state()
@@ -466,8 +467,8 @@ test_that("float/double binom identical behaviour in corner cases", {
 
   ## and a draw and its complement are the same
   n <- 20L
-  ans1 <- dust_rng$new(1, 1, TRUE)$rbinom(100, n, 0.2)
-  ans2 <- dust_rng$new(1, 1, TRUE)$rbinom(100, n, 0.8)
+  ans1 <- dust_rng$new(1, 1, "float")$rbinom(100, n, 0.2)
+  ans2 <- dust_rng$new(1, 1, "float")$rbinom(100, n, 0.8)
   expect_equal(ans1, n - ans2)
 })
 
@@ -475,8 +476,8 @@ test_that("float/double binom identical behaviour in corner cases", {
 test_that("poisson random numbers from floats have correct distribution", {
   n <- 100000
   lambda <- 10
-  yf <- dust_rng$new(1, 1, TRUE)$rpois(n, lambda)
-  yd <- dust_rng$new(1, 1, FALSE)$rpois(n, lambda)
+  yf <- dust_rng$new(1, 1, "float")$rpois(n, lambda)
+  yd <- dust_rng$new(1, 1, "double")$rpois(n, lambda)
   expect_equal(mean(yf), mean(yd), tolerance = 1e-4)
   expect_equal(var(yf), var(yd), tolerance = 1e-3)
 })
@@ -486,8 +487,8 @@ test_that("uniform random numbers from floats have correct distribution", {
   n <- 100000
   min <- -2
   max <- 4
-  yf <- dust_rng$new(1, 1, TRUE)$runif(n, min, max)
-  yd <- dust_rng$new(1, 1, FALSE)$runif(n, min, max)
+  yf <- dust_rng$new(1, 1, "float")$runif(n, min, max)
+  yd <- dust_rng$new(1, 1, "double")$runif(n, min, max)
   expect_lt(max(abs(yf - yd)), 1e-6)
 })
 
@@ -496,24 +497,24 @@ test_that("normal random numbers from floats have correct distribution", {
   n <- 100000
   mu <- 2
   sd <- 0.1
-  yf <- dust_rng$new(1, 1, TRUE)$rnorm(n, mu, sd)
-  yd <- dust_rng$new(1, 1, FALSE)$rnorm(n, mu, sd)
+  yf <- dust_rng$new(1, 1, "float")$rnorm(n, mu, sd)
+  yd <- dust_rng$new(1, 1, "double")$rnorm(n, mu, sd)
   expect_lt(max(abs(yf - yd)), 1e-6)
 })
 
 
 test_that("std uniform random numbers from floats have correct distribution", {
   n <- 100000
-  yf <- dust_rng$new(1, 1, TRUE)$unif_rand(n)
-  yd <- dust_rng$new(1, 1, FALSE)$unif_rand(n)
+  yf <- dust_rng$new(1, 1, "float")$unif_rand(n)
+  yd <- dust_rng$new(1, 1, "double")$unif_rand(n)
   expect_lt(max(abs(yf - yd)), 1e-6)
 })
 
 
 test_that("std normal random numbers from floats have correct distribution", {
   n <- 100000
-  yf <- dust_rng$new(1, 1, TRUE)$norm_rand(n)
-  yd <- dust_rng$new(1, 1, FALSE)$norm_rand(n)
+  yf <- dust_rng$new(1, 1, "float")$norm_rand(n)
+  yd <- dust_rng$new(1, 1, "double")$norm_rand(n)
   expect_lt(max(abs(yf - yd)), 4e-6)
 })
 
@@ -521,17 +522,17 @@ test_that("std normal random numbers from floats have correct distribution", {
 test_that("exponential random numbers from floats have correct distribution", {
   n <- 100000
   rate <- 4
-  yf <- dust_rng$new(1, 1, TRUE)$rexp(n, rate)
-  yd <- dust_rng$new(1, 1, FALSE)$rexp(n, rate)
+  yf <- dust_rng$new(1, 1, "float")$rexp(n, rate)
+  yd <- dust_rng$new(1, 1, "double")$rexp(n, rate)
   expect_lt(max(abs(yf - yd)), 1e-6)
 })
 
 
 test_that("float interface works as expected", {
-  rng_f <- dust_rng$new(1, 5, TRUE)
-  rng_d <- dust_rng$new(1, 5, FALSE)
-  expect_equal(rng_f$real_t(), "float")
-  expect_equal(rng_d$real_t(), "double")
+  rng_f <- dust_rng$new(1, 5, "float")
+  rng_d <- dust_rng$new(1, 5, "double")
+  expect_equal(rng_f$real_type(), "float")
+  expect_equal(rng_d$real_type(), "double")
   expect_equal(rng_f$size(), 5L)
   expect_equal(rng_d$size(), 5L)
   expect_identical(rng_f$state(), rng_d$state())

--- a/tests/testthat/test-rng.R
+++ b/tests/testthat/test-rng.R
@@ -115,34 +115,6 @@ test_that("binomial numbers on the 'small' path", {
 })
 
 
-test_that("binomial random numbers from floats have correct distribution", {
-  test_rbinom_double <- function(i, m, n, p) {
-    dust_rng$new(1, 1)$rbinom(m, n, p)
-  }
-  m <- 100000
-  n <- 958L
-  p <- 0.004145
-  yf <- test_rbinom_float(1L, m, n, p)
-  yd <- test_rbinom_double(1L, m, n, p)
-  expect_equal(mean(yf), mean(yd), tolerance = 1e-4)
-  expect_equal(var(yf), var(yd), tolerance = 1e-3)
-})
-
-
-test_that("binomial random numbers from floats have correct distribution", {
-  test_rbinom_double <- function(i, m, n, p) {
-    dust_rng$new(1, 1)$rbinom(m, n, p)
-  }
-  m <- 100000
-  n <- 100L
-  p <- 0.1
-  yf <- test_rbinom_float(1L, m, n, p)
-  yd <- test_rbinom_double(1L, m, n, p)
-  expect_equal(mean(yf), mean(yd), tolerance = 1e-4)
-  expect_equal(var(yf), var(yd), tolerance = 1e-3)
-})
-
-
 test_that("binomial numbers and their complement are the same (np small)", {
   m <- 100
   n <- 20L
@@ -378,6 +350,7 @@ test_that("initialise parallel rng with binary state and drop", {
   rng10 <- dust_rng$new(seed, 10L)
   rng5 <- dust_rng$new(rng10$state(), 5L)
   expect_identical(rng5$state(), rng10$state()[seq_len(5 * 4 * 8)])
+  expect_identical(dust_rng$new(rng10$state(), 5L, TRUE)$state(), rng5$state())
 })
 
 
@@ -388,6 +361,8 @@ test_that("require that raw vector is of sensible size", {
                "Expected raw vector of length as multiple of 32 for 'seed'")
   expect_error(dust_rng$new(raw(63), 1L),
                "Expected raw vector of length as multiple of 32 for 'seed'")
+  expect_error(dust_rng$new(raw(63), 1L, TRUE),
+               "Expected raw vector of length as multiple of 32 for 'seed'")
 })
 
 
@@ -397,8 +372,15 @@ test_that("initialise with NULL, generating a seed from R", {
   set.seed(1)
   rng2 <- dust_rng$new(NULL, 1L)
   rng3 <- dust_rng$new(NULL, 1L)
+  set.seed(1)
+  rng4 <- dust_rng$new(NULL, 1L, TRUE)
+  rng5 <- dust_rng$new(NULL, 1L, TRUE)
+
   expect_identical(rng2$state(), rng1$state())
   expect_false(identical(rng3$state(), rng2$state()))
+
+  expect_identical(rng4$state(), rng1$state())
+  expect_identical(rng5$state(), rng3$state())
 })
 
 
@@ -408,6 +390,9 @@ test_that("can't create rng with silly things", {
     "Invalid type for 'seed'")
   expect_error(
     dust_rng$new(function(x) 2, 1L),
+    "Invalid type for 'seed'")
+  expect_error(
+    dust_rng$new(function(x) 2, 1L, TRUE),
     "Invalid type for 'seed'")
 })
 
@@ -438,4 +423,122 @@ test_that("can jump the rng state with dust_rng_state_long_jump", {
   expect_identical(dust_rng_state_long_jump(state), r1)
   expect_identical(dust_rng_state_long_jump(state), r1)
   expect_identical(dust_rng_state_long_jump(state, 2), r2)
+})
+
+
+test_that("binomial random numbers from floats have correct distribution", {
+  m <- 100000
+  n <- 958L
+  p <- 0.004145
+  yf <- dust_rng$new(1, 1, TRUE)$rbinom(m, n, p)
+  yd <- dust_rng$new(1, 1, FALSE)$rbinom(m, n, p)
+  expect_equal(mean(yf), mean(yd), tolerance = 1e-4)
+  expect_equal(var(yf), var(yd), tolerance = 1e-3)
+})
+
+
+test_that("binomial random numbers from floats have correct distribution", {
+  m <- 100000
+  n <- 100L
+  p <- 0.1
+  yf <- dust_rng$new(1, 1, TRUE)$rbinom(m, n, p)
+  yd <- dust_rng$new(1, 1, FALSE)$rbinom(m, n, p)
+  expect_equal(mean(yf), mean(yd), tolerance = 1e-4)
+  expect_equal(var(yf), var(yd), tolerance = 1e-3)
+})
+
+
+test_that("float/double binom identical behaviour in corner cases", {
+  rng_f <- dust_rng$new(1, 1, TRUE)
+
+  ## Short circuiting does not advance rng:
+  s <- rng_f$state()
+  expect_equal(rng_f$rbinom(100, 0, 0.1), rep(0, 100))
+  expect_equal(rng_f$rbinom(100, 5, 0), rep(0, 100))
+  expect_equal(rng_f$rbinom(100, 5, 1), rep(5, 100))
+  expect_identical(rng_f$state(), s)
+
+  ## ...nor does an error
+  expect_error(
+    rng_f$rbinom(100, -1, 0.5),
+    "Invalid call to rbinom with n = -1, p = 0.5")
+  expect_identical(rng_f$state(), s)
+
+  ## and a draw and its complement are the same
+  n <- 20L
+  ans1 <- dust_rng$new(1, 1, TRUE)$rbinom(100, n, 0.2)
+  ans2 <- dust_rng$new(1, 1, TRUE)$rbinom(100, n, 0.8)
+  expect_equal(ans1, n - ans2)
+})
+
+
+test_that("poisson random numbers from floats have correct distribution", {
+  n <- 100000
+  lambda <- 10
+  yf <- dust_rng$new(1, 1, TRUE)$rpois(n, lambda)
+  yd <- dust_rng$new(1, 1, FALSE)$rpois(n, lambda)
+  expect_equal(mean(yf), mean(yd), tolerance = 1e-4)
+  expect_equal(var(yf), var(yd), tolerance = 1e-3)
+})
+
+
+test_that("uniform random numbers from floats have correct distribution", {
+  n <- 100000
+  min <- -2
+  max <- 4
+  yf <- dust_rng$new(1, 1, TRUE)$runif(n, min, max)
+  yd <- dust_rng$new(1, 1, FALSE)$runif(n, min, max)
+  expect_lt(max(abs(yf - yd)), 1e-6)
+})
+
+
+test_that("normal random numbers from floats have correct distribution", {
+  n <- 100000
+  mu <- 2
+  sd <- 0.1
+  yf <- dust_rng$new(1, 1, TRUE)$rnorm(n, mu, sd)
+  yd <- dust_rng$new(1, 1, FALSE)$rnorm(n, mu, sd)
+  expect_lt(max(abs(yf - yd)), 1e-6)
+})
+
+
+test_that("std uniform random numbers from floats have correct distribution", {
+  n <- 100000
+  yf <- dust_rng$new(1, 1, TRUE)$unif_rand(n)
+  yd <- dust_rng$new(1, 1, FALSE)$unif_rand(n)
+  expect_lt(max(abs(yf - yd)), 1e-6)
+})
+
+
+test_that("std normal random numbers from floats have correct distribution", {
+  n <- 100000
+  yf <- dust_rng$new(1, 1, TRUE)$norm_rand(n)
+  yd <- dust_rng$new(1, 1, FALSE)$norm_rand(n)
+  expect_lt(max(abs(yf - yd)), 4e-6)
+})
+
+
+test_that("exponential random numbers from floats have correct distribution", {
+  n <- 100000
+  rate <- 4
+  yf <- dust_rng$new(1, 1, TRUE)$rexp(n, rate)
+  yd <- dust_rng$new(1, 1, FALSE)$rexp(n, rate)
+  expect_lt(max(abs(yf - yd)), 1e-6)
+})
+
+
+test_that("float interface works as expected", {
+  rng_f <- dust_rng$new(1, 5, TRUE)
+  rng_d <- dust_rng$new(1, 5, FALSE)
+  expect_equal(rng_f$real_t(), "float")
+  expect_equal(rng_d$real_t(), "double")
+  expect_equal(rng_f$size(), 5L)
+  expect_equal(rng_d$size(), 5L)
+  expect_identical(rng_f$state(), rng_d$state())
+  rng_f$jump()
+  rng_d$jump()
+  expect_identical(rng_f$state(), rng_d$state())
+  rng_f$long_jump()
+  rng_d$long_jump()
+  expect_identical(rng_f$state(), rng_d$state())
 })

--- a/tests/testthat/test-rng.R
+++ b/tests/testthat/test-rng.R
@@ -543,3 +543,10 @@ test_that("float interface works as expected", {
   rng_d$long_jump()
   expect_identical(rng_f$state(), rng_d$state())
 })
+
+
+test_that("Require double or float", {
+  expect_error(
+    dust_rng$new(1, 5, "binary16"),
+    "Invalid value for 'real_type': must be 'double' or 'float'")
+})


### PR DESCRIPTION
This PR allows running all the rngs in float mode. This will hopefully make corner cases easier to work with as we hit them

Fixes #191 