### PR TITLE
Fix error handling in multiparameter case

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dust
 Title: Iterate Multiple Realisations of Stochastic Models
-Version: 0.8.18
+Version: 0.8.19
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("John", "Lees", role = "aut"),

--- a/inst/include/dust/dust.hpp
+++ b/inst/include/dust/dust.hpp
@@ -38,7 +38,7 @@ public:
     n_threads_(n_threads),
     device_id_(device_id),
     rng_(n_particles_total_, seed),
-    errors_(n_particles),
+    errors_(n_particles_total_),
     stale_host_(false),
     stale_device_(true) {
 #ifdef __NVCC__
@@ -60,7 +60,7 @@ public:
     n_threads_(n_threads),
     device_id_(device_id),
     rng_(n_particles_total_, seed),
-    errors_(n_particles),
+    errors_(n_particles_total_),
     stale_host_(false),
     stale_device_(true) {
 #ifdef __NVCC__

--- a/tests/testthat/test-example.R
+++ b/tests/testthat/test-example.R
@@ -681,6 +681,19 @@ test_that("Truncate errors past certain point", {
 })
 
 
+test_that("more binomial errors", {
+  res <- dust_example("sir")
+  set.seed(1)
+  gamma <- runif(100, max = 0.1)
+  gamma[c(10, 20, 30)] <- -gamma[c(10, 20, 30)]
+  par <- apply(cbind(beta = 0.15, gamma = gamma), 1, as.list)
+  mod <- res$new(par, 0, NULL, seed = 1L, pars_multi = TRUE)
+  err <- expect_error(mod$run(10),
+                      "3 particles reported errors")
+  expect_match(err$message, "10: Invalid call to rbinom")
+})
+
+
 test_that("steps must not be negative", {
   res <- dust_example("sir")
   y0 <- matrix(1, 1, 5)

--- a/tests/testthat/test-multi.R
+++ b/tests/testthat/test-multi.R
@@ -680,3 +680,18 @@ test_that("Can set state into a multiparameter model, unshared + structured", {
   expect_error(mod$set_state(y[, 1, , drop = FALSE]),
                "Expected dimension 2 of 'state' to be 3 but given 1")
 })
+
+
+test_that("Reorder across particles", {
+  res <- dust_example("variable")
+  p <- lapply(runif(6), function(x) list(len = 5, sd = x))
+  mod <- res$new(p, 0, NULL, pars_multi = TRUE)
+
+  s <- mod$state()
+  y <- array(as.numeric(seq_along(s)), dim(s))
+  mod$set_state(y)
+
+  i <- sample.int(length(p), replace = TRUE)
+  mod$reorder(i)
+  expect_equal(mod$state(), y[, i])
+})


### PR DESCRIPTION
This PR fixes a small bug where we were allocating the wrong space for the error handling in the multiparameter case (found when working on the if2 data).

Fixes #172 (in addition to the above - added the test; behaviour was correct already)