### PR TITLE
Keep history in host memory with CUDA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ inst/doc
 pkgdown
 inst/include/cub
 *.gcov
+
+.vscode/

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dust
 Title: Iterate Multiple Realisations of Stochastic Models
-Version: 0.9.0
+Version: 0.9.1
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("John", "Lees", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# dust 0.9.1
+
+* Move history and snapshot saving out of VRAM, and make it asynchronous.
+
 # dust 0.9.0
 
 * Added CUDA version of the particle filter, run with `model$filter(device = TRUE)` (#224)

--- a/inst/include/dust/containers.hpp
+++ b/inst/include/dust/containers.hpp
@@ -119,6 +119,20 @@ public:
 #endif
   }
 
+  void get_array(T * dst, cuda_stream& stream, const bool async = false) const {
+#ifdef __NVCC__
+    if (async) {
+      CUDA_CALL(cudaMemcpyAsync(dst, data_, dst.size() * sizeof(T),
+                          cudaMemcpyDefault, stream.stream()));
+    } else {
+      CUDA_CALL(cudaMemcpy(dst, data_, dst.size() * sizeof(T),
+                          cudaMemcpyDefault));
+    }
+#else
+    std::memcpy(dst, data_, dst.size() * sizeof(T));
+#endif
+  }
+
   // General method to set the device array, allowing src to be written
   // into the device data_ array starting at dst_offset
   void set_array(const T* src, const size_t src_size,

--- a/inst/include/dust/containers.hpp
+++ b/inst/include/dust/containers.hpp
@@ -122,14 +122,14 @@ public:
   void get_array(T * dst, dust::cuda::cuda_stream& stream, const bool async = false) const {
 #ifdef __NVCC__
     if (async) {
-      CUDA_CALL(cudaMemcpyAsync(dst, data_, dst.size() * sizeof(T),
+      CUDA_CALL(cudaMemcpyAsync(dst, data_, size() * sizeof(T),
                           cudaMemcpyDefault, stream.stream()));
     } else {
-      CUDA_CALL(cudaMemcpy(dst, data_, dst.size() * sizeof(T),
+      CUDA_CALL(cudaMemcpy(dst, data_, size() * sizeof(T),
                           cudaMemcpyDefault));
     }
 #else
-    std::memcpy(dst, data_, dst.size() * sizeof(T));
+    std::memcpy(dst, data_, size() * sizeof(T));
 #endif
   }
 

--- a/inst/include/dust/containers.hpp
+++ b/inst/include/dust/containers.hpp
@@ -167,6 +167,19 @@ public:
 #endif
   }
 
+#ifdef __NVCC__
+  // Async memory operations on non-default stream
+  void get_array_async(T * dst, cuda_stream& stream) const {
+      CUDA_CALL(cudaMemcpyAsync(dst, data_, dst.size() * sizeof(T),
+                          cudaMemcpyDefault, stream.stream()));
+  }
+
+  void set_array_async(T * dst, cuda_stream& stream) const {
+      CUDA_CALL(cudaMemcpyAsync(data_, dst, size() * sizeof(T),
+                          cudaMemcpyDefault, stream.stream()));
+  }
+#endif
+
   T* data() {
     return data_;
   }

--- a/inst/include/dust/containers.hpp
+++ b/inst/include/dust/containers.hpp
@@ -167,18 +167,24 @@ public:
 #endif
   }
 
-#ifdef __NVCC__
   // Async memory operations on non-default stream
-  void get_array_async(T * dst, cuda_stream& stream) const {
-      CUDA_CALL(cudaMemcpyAsync(dst, data_, dst.size() * sizeof(T),
-                          cudaMemcpyDefault, stream.stream()));
+  void get_array_async(T * dst, dust::cuda::cuda_stream& stream) const {
+#ifdef __NVCC__
+    CUDA_CALL(cudaMemcpyAsync(dst, data_, size() * sizeof(T),
+                              cudaMemcpyDefault, stream.stream()));
+#else
+    std::memcpy(dst, data_, size() * sizeof(T));
+#endif
   }
 
-  void set_array_async(T * dst, cuda_stream& stream) const {
-      CUDA_CALL(cudaMemcpyAsync(data_, dst, size() * sizeof(T),
-                          cudaMemcpyDefault, stream.stream()));
-  }
+  void set_array_async(T * dst, dust::cuda::cuda_stream& stream) const {
+#ifdef __NVCC__
+    CUDA_CALL(cudaMemcpyAsync(data_, dst, size() * sizeof(T),
+                              cudaMemcpyDefault, stream.stream()));
+#else
+    std::memcpy(data_, dst, size() * sizeof(T));
 #endif
+  }
 
   T* data() {
     return data_;

--- a/inst/include/dust/containers.hpp
+++ b/inst/include/dust/containers.hpp
@@ -119,7 +119,7 @@ public:
 #endif
   }
 
-  void get_array(T * dst, cuda_stream& stream, const bool async = false) const {
+  void get_array(T * dst, dust::cuda::cuda_stream& stream, const bool async = false) const {
 #ifdef __NVCC__
     if (async) {
       CUDA_CALL(cudaMemcpyAsync(dst, data_, dst.size() * sizeof(T),
@@ -167,20 +167,15 @@ public:
 #endif
   }
 
-  // Async memory operations on non-default stream
-  void get_array_async(T * dst, dust::cuda::cuda_stream& stream) const {
+  void set_array(T * dst, dust::cuda::cuda_stream& stream, const bool async = false) const {
 #ifdef __NVCC__
-    CUDA_CALL(cudaMemcpyAsync(dst, data_, size() * sizeof(T),
-                              cudaMemcpyDefault, stream.stream()));
-#else
-    std::memcpy(dst, data_, size() * sizeof(T));
-#endif
-  }
-
-  void set_array_async(T * dst, dust::cuda::cuda_stream& stream) const {
-#ifdef __NVCC__
-    CUDA_CALL(cudaMemcpyAsync(data_, dst, size() * sizeof(T),
-                              cudaMemcpyDefault, stream.stream()));
+    if (async) {
+      CUDA_CALL(cudaMemcpyAsync(data_, dst, size() * sizeof(T),
+                                cudaMemcpyDefault, stream.stream()));
+    } else {
+      CUDA_CALL(cudaMemcpy(data_, dst, size() * sizeof(T),
+                           cudaMemcpyDefault));
+    }
 #else
     std::memcpy(data_, dst, size() * sizeof(T));
 #endif

--- a/inst/include/dust/cuda.cuh
+++ b/inst/include/dust/cuda.cuh
@@ -79,6 +79,42 @@ DEVICE void shared_mem_wait(cooperative_groups::thread_block& block) {
 }
 #endif
 
+class cuda_stream {
+public:
+  cuda_stream() {
+    CUDA_CALL(cudaStreamCreate(&stream_));
+  }
+
+  ~cuda_stream() {
+    CUDA_CALL_NOTHROW(cudaStreamCreate(stream_));
+  }
+
+  cudaStream_t& stream() {
+    return stream_;
+  }
+
+  void sync() {
+    CUDA_CALL(cudaStreamSynchronize(stream_));
+  }
+
+  bool query() const {
+    bool ready;
+    if (cudaStreamQuery(stream_) == cudaSuccess) {
+      ready = true;
+    } else {
+      ready = false;
+    }
+    return ready;
+  }
+
+private:
+  // Delete copy and move
+  cuda_stream ( const cuda_stream & ) = delete;
+  cuda_stream ( cuda_stream && ) = delete;
+
+  cudaStream_t stream_;
+}
+
 }
 }
 

--- a/inst/include/dust/cuda.cuh
+++ b/inst/include/dust/cuda.cuh
@@ -87,10 +87,9 @@ public:
 #ifdef __NVCC__
     // Handle error manually, as this may be called when nvcc has been used
     // to compile, but no device is present on the executing system
-    cudaStreamCreate(&stream_);
-    cudaError_t status = cudaGetLastError();
+    cudaError_t status = cudaStreamCreate(&stream_);
     if (status == cudaErrorNoDevice) {
-      &stream_ = nullptr;
+      stream_ = nullptr;
     } else if (status != cudaSuccess) {
       dust::cuda::throw_cuda_error(__FILE__, __LINE__, status);
     }
@@ -99,7 +98,7 @@ public:
 
 #ifdef __NVCC__
   ~cuda_stream() {
-    if (&stream_ != nullptr) {
+    if (stream_ != nullptr) {
       CUDA_CALL_NOTHROW(cudaStreamDestroy(stream_));
     }
   }

--- a/inst/include/dust/cuda.cuh
+++ b/inst/include/dust/cuda.cuh
@@ -94,7 +94,7 @@ public:
     CUDA_CALL_NOTHROW(cudaStreamDestroy(stream_));
   }
 
-  cudaStream_t& stream() {
+  cudaStream_t stream() {
     return stream_;
   }
 #endif

--- a/inst/include/dust/cuda.cuh
+++ b/inst/include/dust/cuda.cuh
@@ -91,7 +91,7 @@ public:
 
 #ifdef __NVCC__
   ~cuda_stream() {
-    CUDA_CALL_NOTHROW(cudaStreamCreate(stream_));
+    CUDA_CALL_NOTHROW(cudaStreamDestroy(stream_));
   }
 
   cudaStream_t& stream() {

--- a/inst/include/dust/cuda.cuh
+++ b/inst/include/dust/cuda.cuh
@@ -123,7 +123,7 @@ private:
 #ifdef __NVCC__
   cudaStream_t stream_;
 #endif
-}
+};
 
 }
 }

--- a/inst/include/dust/device_resample.hpp
+++ b/inst/include/dust/device_resample.hpp
@@ -44,7 +44,8 @@ void run_device_resample(const size_t n_particles,
     for (size_t i = 0; i < n_pars; ++i) {
       shuffle_draws[i] = dust::unif_rand(resample_rng);
     }
-    device_state.resample_u.set_array(shuffle_draws, resample_stream, true);
+    device_state.resample_u.set_array(shuffle_draws.data(),
+                                      resample_stream, true);
 
     // Now sync the streams
     kernel_stream.sync();

--- a/inst/include/dust/device_resample.hpp
+++ b/inst/include/dust/device_resample.hpp
@@ -44,7 +44,7 @@ void run_device_resample(const size_t n_particles,
     for (size_t i = 0; i < n_pars; ++i) {
       shuffle_draws[i] = dust::unif_rand(resample_rng);
     }
-    device_state.resample_u.set_array_async(shuffle_draws, resample_stream);
+    device_state.resample_u.set_array(shuffle_draws, resample_stream, true);
 
     // Now sync the streams
     kernel_stream.sync();

--- a/inst/include/dust/device_resample.hpp
+++ b/inst/include/dust/device_resample.hpp
@@ -10,6 +10,8 @@ void run_device_resample(const size_t n_particles,
                          const size_t n_pars,
                          const size_t n_state,
                          const cuda_launch& cuda_pars,
+                         cuda_stream& kernel_stream,
+                         cuda_stream& resample_stream,
                          rng_state_t<real_t>& resample_rng,
                          dust::device_state<real_t>& device_state,
                          dust::device_array<real_t>& weights,
@@ -22,7 +24,8 @@ void run_device_resample(const size_t n_particles,
                                   scan.tmp_bytes,
                                   weights.data(),
                                   scan.cum_weights.data(),
-                                  scan.cum_weights.size());
+                                  scan.cum_weights.size(),
+                                  kernel_stream.stream());
     // Don't sync yet, as this can run while the u draws are made and copied
     // to the device
 #else
@@ -41,19 +44,29 @@ void run_device_resample(const size_t n_particles,
     for (size_t i = 0; i < n_pars; ++i) {
       shuffle_draws[i] = dust::unif_rand(resample_rng);
     }
-    // Copying this also syncs the prefix scan
+#ifdef __NVCC__
+    device_state.resample_u.set_array_async(shuffle_draws, resample_stream);
+
+    // Now sync the streams
+    kernel_stream.sync();
+    resample_stream.sync();
+#else
     device_state.resample_u.set_array(shuffle_draws);
+#endif
 
     // Generate the scatter indices
 #ifdef __NVCC__
-    dust::find_intervals<real_t><<<cuda_pars.interval_blockCount, cuda_pars.interval_blockSize>>>(
+    dust::find_intervals<real_t><<<cuda_pars.interval_blockCount,
+                                   cuda_pars.interval_blockSize,
+                                   0,
+                                   kernel_stream.stream()>>>(
       scan.cum_weights.data(),
       n_particles,
       n_pars,
       device_state.scatter_index.data(),
       device_state.resample_u.data()
     );
-    CUDA_CALL(cudaDeviceSynchronize());
+    kernel_stream.sync();
 #else
     dust::find_intervals<real_t>(
       scan.cum_weights.data(),
@@ -66,7 +79,10 @@ void run_device_resample(const size_t n_particles,
 
     // Shuffle the particles
 #ifdef __NVCC__
-    dust::scatter_device<real_t><<<cuda_pars.scatter_blockCount, cuda_pars.scatter_blockSize>>>(
+    dust::scatter_device<real_t><<<cuda_pars.scatter_blockCount,
+                                   cuda_pars.scatter_blockSize,
+                                   0,
+                                   kernel_stream.stream()>>>(
         device_state.scatter_index.data(),
         device_state.y.data(),
         device_state.y_next.data(),

--- a/inst/include/dust/dust.hpp
+++ b/inst/include/dust/dust.hpp
@@ -430,13 +430,13 @@ public:
     return device_state_.scatter_index;
   }
 
-  dust::device_array<size_t>& device_state_full() {
+  dust::device_array<real_t>& device_state_full() {
     refresh_device();
     kernel_stream_.sync();
     return device_state_.y;
   }
 
-  dust::device_array<size_t>& device_state_selected() {
+  dust::device_array<real_t>& device_state_selected() {
     refresh_device();
     run_device_select();
     kernel_stream_.sync();

--- a/inst/include/dust/dust.hpp
+++ b/inst/include/dust/dust.hpp
@@ -189,7 +189,8 @@ public:
 #ifdef __NVCC__
       dust::run_particles<T><<<cuda_pars_.run_blockCount,
                                cuda_pars_.run_blockSize,
-                               cuda_pars_.run_shared_size_bytes>>>(
+                               cuda_pars_.run_shared_size_bytes,
+                               kernel_stream_.stream()>>>(
                       step_start, step_end, particles_.size(),
                       n_pars_effective(),
                       device_state_.y.data(), device_state_.y_next.data(),
@@ -201,7 +202,7 @@ public:
                       device_state_.shared_real.data(),
                       device_state_.rng.data(),
                       cuda_pars_.run_L1);
-      CUDA_CALL(cudaDeviceSynchronize());
+      kernel_stream_.sync();
 #else
       dust::run_particles<T>(step_start, step_end, particles_.size(),
                       n_pars_effective(),
@@ -263,9 +264,7 @@ public:
     if (stale_host_) {
       // Run the selection and copy items back
       run_device_select();
-#ifdef __NVCC__
-      CUDA_CALL(cudaDeviceSynchronize());
-#endif
+      kernel_stream_.sync();
       std::vector<real_t> y_selected(np * index_size);
       device_state_.y_selected.get_array(y_selected);
 
@@ -283,24 +282,6 @@ public:
       for (size_t i = 0; i < np; ++i) {
         particles_[i].state(index_, end_state + i * index_size);
       }
-    }
-  }
-
-  // Used for copy of state into another block of memory on the device (used
-  // for history saving)
-  void state(dust::filter_trajectories_device<real_t>& device_state,
-             const bool async = false) {
-    refresh_device();
-    run_device_select();
-#ifdef __NVCC__
-    kernel_stream_.sync();
-#endif
-    device_state.value_swap.set_array(device_state_.y_selected.data(),
-                                      device_state_.y_selected.size(),
-                                      async);
-    device_state.values_to_host(memory_stream_.stream());
-    if (!async) {
-      memory_stream_.sync();
     }
   }
 
@@ -357,14 +338,17 @@ public:
       size_t n_state = n_state_full();
       device_state_.scatter_index.set_array(index);
 #ifdef __NVCC__
-      dust::scatter_device<real_t><<<cuda_pars_.reorder_blockCount, cuda_pars_.reorder_blockSize>>>(
+      dust::scatter_device<real_t><<<cuda_pars_.reorder_blockCount,
+                                     cuda_pars_.reorder_blockSize,
+                                     0,
+                                     kernel_stream_.stream()>>>(
         device_state_.scatter_index.data(),
         device_state_.y.data(),
         device_state_.y_next.data(),
         n_state,
         n_particles,
         false);
-      CUDA_CALL(cudaDeviceSynchronize());
+      kernel_stream.sync();
 #else
       dust::scatter_device<real_t>(
         device_state_.scatter_index.data(),
@@ -435,21 +419,32 @@ public:
                 dust::device_scan_state<real_t>& scan) {
     refresh_device();
     dust::filter::run_device_resample(n_particles(), n_pars_effective(), n_state_full(),
-                                      cuda_pars_, rng_.state(n_particles()),
+                                      cuda_pars_, kernel_stream_, resample_stream_,
+                                      rng_.state(n_particles()),
                                       device_state_, weights, scan);
     select_needed_ = true;
   }
 
-  // Used in the filter
-  void kappa_copy(dust::filter_trajectories_device<real_t>& device_state,
-                  const bool async = false) {
-    device_state.order_swap.set_array(device_state_.scatter_index.data(),
-                                      device_state_.scatter_index.size(),
-                                      async);
-    device_state.order_to_host(memory_stream_.stream());
-    if (!async) {
-      memory_stream_.sync();
-    }
+  // Functions used in the device filter
+  dust::device_array<size_t>& kappa() {
+    return device_state_.scatter_index;
+  }
+
+  dust::device_array<size_t>& device_state_full() {
+    refresh_device();
+#ifdef __NVCC__
+    kernel_stream_.sync();
+#endif
+    return device_state_.y;
+  }
+
+  dust::device_array<size_t>& device_state_selected() {
+    refresh_device();
+    run_device_select();
+#ifdef __NVCC__
+    kernel_stream_.sync();
+#endif
+    return device_state_.y_selected;
   }
 
   size_t n_threads() const {
@@ -588,7 +583,8 @@ public:
 #ifdef __NVCC__
     dust::compare_particles<T><<<cuda_pars_.compare_blockCount,
                                  cuda_pars_.compare_blockSize,
-                                 cuda_pars_.compare_shared_size_bytes>>>(
+                                 cuda_pars_.compare_shared_size_bytes,
+                                 kernel_stream_.stream()>>>(
                      particles_.size(),
                      n_pars_effective(),
                      device_state_.y.data(),
@@ -602,7 +598,7 @@ public:
                      device_data_.data() + data_offset,
                      device_state_.rng.data(),
                      cuda_pars_.compare_L1);
-    CUDA_CALL(cudaDeviceSynchronize());
+    kernel_stream_.sync();
 #else
     dust::compare_particles<T>(
                      particles_.size(),
@@ -653,7 +649,7 @@ private:
 
 #ifdef __NVCC__
   dust::cuda::cuda_stream kernel_stream_;
-  dust::cuda::cuda_stream memory_stream_;
+  dust::cuda::cuda_stream resample_stream_;
 #endif
 
   // delete move and copy to avoid accidentally using them
@@ -958,17 +954,21 @@ private:
                                 device_state_.index.data(),
                                 device_state_.y_selected.data(),
                                 device_state_.n_selected.data(),
-                                device_state_.y.size());
+                                device_state_.y.size(),
+                                kernel_stream_.stream());
+    kernel_stream_.sync();
     if (select_scatter_) {
       dust::scatter_device<real_t><<<cuda_pars_.index_scatter_blockCount,
-                                     cuda_pars_.index_scatter_blockSize>>>(
+                                     cuda_pars_.index_scatter_blockSize,
+                                     0,
+                                     kernel_stream_.stream()>>>(
         device_state_.index_state_scatter.data(),
         device_state_.y_selected.data(),
         device_state_.y_selected_swap.data(),
         n_state(),
         n_particles(),
         true);
-      CUDA_CALL(cudaDeviceSynchronize());
+      kernel_stream_.sync();
       device_state_.swap_selected();
     }
 #else

--- a/inst/include/dust/dust.hpp
+++ b/inst/include/dust/dust.hpp
@@ -432,18 +432,14 @@ public:
 
   dust::device_array<size_t>& device_state_full() {
     refresh_device();
-#ifdef __NVCC__
     kernel_stream_.sync();
-#endif
     return device_state_.y;
   }
 
   dust::device_array<size_t>& device_state_selected() {
     refresh_device();
     run_device_select();
-#ifdef __NVCC__
     kernel_stream_.sync();
-#endif
     return device_state_.y_selected;
   }
 
@@ -619,6 +615,10 @@ public:
   }
 
 private:
+  // delete move and copy to avoid accidentally using them
+  Dust ( const Dust & ) = delete;
+  Dust ( Dust && ) = delete;
+
   const size_t n_pars_; // 0 in the "single" case, >=1 otherwise
   const size_t n_particles_each_; // Particles per parameter set
   const size_t n_particles_total_; // Total number of particles
@@ -639,6 +639,8 @@ private:
   dust::device_state<real_t> device_state_;
   dust::device_array<data_t> device_data_;
   std::map<size_t, size_t> device_data_offsets_;
+  dust::cuda::cuda_stream kernel_stream_;
+  dust::cuda::cuda_stream resample_stream_;
 
   bool stale_host_;
   bool stale_device_;
@@ -646,15 +648,6 @@ private:
   bool select_scatter_;
   size_t shared_size_;
   size_t device_step_;
-
-#ifdef __NVCC__
-  dust::cuda::cuda_stream kernel_stream_;
-  dust::cuda::cuda_stream resample_stream_;
-#endif
-
-  // delete move and copy to avoid accidentally using them
-  Dust ( const Dust & ) = delete;
-  Dust ( Dust && ) = delete;
 
   // Sets device
   template <typename U = T>

--- a/inst/include/dust/dust.hpp
+++ b/inst/include/dust/dust.hpp
@@ -348,7 +348,7 @@ public:
         n_state,
         n_particles,
         false);
-      kernel_stream.sync();
+      kernel_stream_.sync();
 #else
       dust::scatter_device<real_t>(
         device_state_.scatter_index.data(),

--- a/inst/include/dust/dust.hpp
+++ b/inst/include/dust/dust.hpp
@@ -264,7 +264,6 @@ public:
     if (stale_host_) {
       // Run the selection and copy items back
       run_device_select();
-      kernel_stream_.sync();
       std::vector<real_t> y_selected(np * index_size);
       device_state_.y_selected.get_array(y_selected);
 
@@ -439,7 +438,6 @@ public:
   dust::device_array<real_t>& device_state_selected() {
     refresh_device();
     run_device_select();
-    kernel_stream_.sync();
     return device_state_.y_selected;
   }
 

--- a/inst/include/dust/dust.hpp
+++ b/inst/include/dust/dust.hpp
@@ -288,15 +288,20 @@ public:
 
   // Used for copy of state into another block of memory on the device (used
   // for history saving)
-  void state(dust::device_array<real_t>& device_state, const size_t dst_offset,
+  void state(dust::filter_trajectories_device<real_t>& device_state,
              const bool async = false) {
     refresh_device();
     run_device_select();
 #ifdef __NVCC__
-    CUDA_CALL(cudaDeviceSynchronize());
+    kernel_stream_.sync();
 #endif
-    device_state.set_array(device_state_.y_selected.data(),
-                           device_state_.y_selected.size(), dst_offset, async);
+    device_state.value_swap.set_array(device_state_.y_selected.data(),
+                                      device_state_.y_selected.size(),
+                                      async);
+    device_state.values_to_host(memory_stream_.stream());
+    if (!async) {
+      memory_stream_.sync();
+    }
   }
 
   // TODO: this does not use device_select. But if index is being provided
@@ -436,8 +441,15 @@ public:
   }
 
   // Used in the filter
-  dust::device_array<size_t>& kappa() {
-    return device_state_.scatter_index;
+  void kappa_copy(dust::filter_trajectories_device<real_t>& device_state,
+                  const bool async = false) {
+    device_state.order_swap.set_array(device_state_.scatter_index.data(),
+                                      device_state_.scatter_index.size(),
+                                      async);
+    device_state.order_to_host(memory_stream_.stream());
+    if (!async) {
+      memory_stream_.sync();
+    }
   }
 
   size_t n_threads() const {
@@ -638,6 +650,11 @@ private:
   bool select_scatter_;
   size_t shared_size_;
   size_t device_step_;
+
+#ifdef __NVCC__
+  dust::cuda::cuda_stream kernel_stream_;
+  dust::cuda::cuda_stream memory_stream_;
+#endif
 
   // delete move and copy to avoid accidentally using them
   Dust ( const Dust & ) = delete;

--- a/inst/include/dust/filter.hpp
+++ b/inst/include/dust/filter.hpp
@@ -103,7 +103,7 @@ filter(Dust<T> * obj,
 
   if (save_trajectories) {
     state.trajectories.resize(obj->n_state(), n_particles, n_data);
-    obj->state(state.trajectories.values(), state.trajectories.value_offset());
+    obj->state(state.trajectories);
     state.trajectories.advance();
   }
 
@@ -115,9 +115,7 @@ filter(Dust<T> * obj,
 
     // SAVE HISTORY (async)
     if (save_trajectories) {
-      obj->state(state.trajectories.values(),
-                 state.trajectories.value_offset(),
-                 true);
+      obj->state(state.trajectories, true);
     }
 
     // COMPARISON FUNCTION
@@ -132,8 +130,7 @@ filter(Dust<T> * obj,
 
     // SAVE HISTORY ORDER
     if (save_trajectories) {
-      state.trajectories.order().set_array(obj->kappa().data(), n_particles,
-        state.trajectories.order_offset());
+      obj->kappa_copy(state.trajectories, true);
       state.trajectories.advance();
     }
 

--- a/inst/include/dust/filter.hpp
+++ b/inst/include/dust/filter.hpp
@@ -103,7 +103,7 @@ filter(Dust<T> * obj,
 
   if (save_trajectories) {
     state.trajectories.resize(obj->n_state(), n_particles, n_data);
-    obj->state(state.trajectories);
+    state.trajectories.store_values(obj->device_state_selected());
     state.trajectories.advance();
   }
 
@@ -115,7 +115,7 @@ filter(Dust<T> * obj,
 
     // SAVE HISTORY (async)
     if (save_trajectories) {
-      obj->state(state.trajectories, true);
+      state.trajectories.store_values(obj->device_state_selected());
     }
 
     // COMPARISON FUNCTION
@@ -130,18 +130,18 @@ filter(Dust<T> * obj,
 
     // SAVE HISTORY ORDER
     if (save_trajectories) {
-      obj->kappa_copy(state.trajectories, true);
+      state.trajectories.store_order(obj->kappa());
       state.trajectories.advance();
     }
 
     // SAVE SNAPSHOT
     if (state.snapshots.is_snapshot_step(d.first)) {
-      obj->state_full(state.snapshots.state(), state.snapshots.value_offset());
+      state.snapshots.store(obj->device_state_full());
       state.snapshots.advance();
     }
   }
 
-  // Copy likelihoods back to host
+  // Copy likelihoods back to host (this will sync everything)
   log_likelihood.get_array(ll_host);
   return ll_host;
 }

--- a/inst/include/dust/filter_state.hpp
+++ b/inst/include/dust/filter_state.hpp
@@ -7,15 +7,37 @@ namespace dust {
 namespace filter {
 
 template <typename real_t>
-class filter_trajectories {
+class filter_trajectories_host {
 public:
-  filter_trajectories() {
+  filter_trajectories_host() {
   }
 
-  virtual size_t size() const = 0; // Pure virtual
+  void resize(size_t n_state, size_t n_particles, size_t n_data) {
+    n_state_ = n_state;
+    n_particles_ = n_particles;
+    n_data_ = n_data;
+    offset_ = 0;
+    history_value.resize(n_state_ * n_particles_ * (n_data_ + 1));
+    history_order.resize(n_particles_ * (n_data_ + 1));
+    for (size_t i = 0; i < n_particles_; ++i) {
+      history_order[i] = i;
+    }
+  }
+
+  size_t size() const {
+    return history_value.size();;
+  }
 
   void advance() {
     offset_++;
+  }
+
+  typename std::vector<real_t>::iterator value_iterator() {
+    return history_value.begin() + offset_ * n_state_ * n_particles_;
+  }
+
+  typename std::vector<size_t>::iterator order_iterator() {
+    return history_order.begin() + offset_ * n_particles_;
   }
 
   std::vector<real_t> history() const {
@@ -66,126 +88,122 @@ public:
     }
   }
 
+  template <typename Iterator>
+  void history(Iterator ret) const {
+    particle_ancestry(ret, history_value.cbegin(), history_order.cbegin());
+  }
+
 protected:
   size_t n_state_;
   size_t n_particles_;
   size_t n_data_;
   size_t offset_;
-};
 
-// The first issue is that we need real names for these things. One is
-// the indexed state that we store over all time - these are
-// "trajectories". The other all state at a few times - these are
-// "snapshots"
-template <typename real_t>
-class filter_trajectories_host : public filter_trajectories<real_t> {
-public:
-  filter_trajectories_host() {
-  }
-
-  void resize(size_t n_state, size_t n_particles, size_t n_data) {
-    this->n_state_ = n_state;
-    this->n_particles_ = n_particles;
-    this->n_data_ = n_data;
-    this->offset_ = 0;
-    history_value.resize(this->n_state_ * this->n_particles_ * (this->n_data_ + 1));
-    history_order.resize(this->n_particles_ * (this->n_data_ + 1));
-    for (size_t i = 0; i < this->n_particles_; ++i) {
-      history_order[i] = i;
-    }
-  }
-
-  size_t size() const {
-    return history_value.size();
-  }
-
-  typename std::vector<real_t>::iterator value_iterator() {
-    return history_value.begin() + this->offset_ * this->n_state_ * this->n_particles_;
-  }
-
-  typename std::vector<size_t>::iterator order_iterator() {
-    return history_order.begin() + this->offset_ * this->n_particles_;
-  }
-
-  template <typename Iterator>
-  void history(Iterator ret) const {
-    this->particle_ancestry(ret, history_value.cbegin(), history_order.cbegin());
-  }
-
-private:
   std::vector<real_t> history_value;
   std::vector<size_t> history_order;
 };
 
 template <typename real_t>
-class filter_trajectories_device : public filter_trajectories<real_t> {
+class filter_trajectories_device : public filter_trajectories_host<real_t> {
 public:
   filter_trajectories_device() {
+    history_value_swap = dust::device_array<real_t>(this->n_state_ * this->n_particles_);
+    history_order_swap = dust::device_array<size_t>(this->n_particles_);
   }
 
+#ifdef __NVCC__
+  ~filter_trajectories_device() {
+    pageable();
+  }
+#endif
+
   void resize(size_t n_state, size_t n_particles, size_t n_data) {
+    pageable();
     this->n_state_ = n_state;
     this->n_particles_ = n_particles;
     this->n_data_ = n_data;
     this->offset_ = 0;
-    history_value = dust::device_array<real_t>(this->n_state_ * this->n_particles_ * (this->n_data_ + 1));
-    history_order = dust::device_array<size_t>(this->n_particles_ * (this->n_data_ + 1));
-    std::vector<size_t> index_init(this->n_particles_);
-    std::iota(index_init.begin(), index_init.end(), 0);
-    history_order.set_array(index_init);
+    this->history_value.resize(this->n_state_ * this->n_particles_ * (this->n_data_ + 1));
+    this->history_order.resize(this->n_particles_ * (this->n_data_ + 1));
+    for (size_t i = 0; i < this->n_particles_; ++i) {
+      this->history_order[i] = i;
+    }
+
+#ifdef __NVCC__
+    // Page lock memory on host
+    CUDA_CALL(cudaHostRegister(this->history_value.data(),
+                               this->history_value.size() * sizeof(real_t),
+                               cudaHostRegisterDefault));
+    CUDA_CALL(cudaHostRegister(this->history_order.data(),
+                               this->history_order.size() * sizeof(real_t),
+                               cudaHostRegisterDefault));
+#endif
+
   }
 
-  size_t size() const {
-    return history_value.size();
-  }
-
-  size_t value_offset() {
-    return this->offset_ * this->n_state_ * this->n_particles_;
-  }
-
-  size_t order_offset() {
-    return this->offset_ * this->n_particles_;
-  }
-
-  dust::device_array<real_t> &values() {
+  dust::device_array<real_t> &value_swap() {
     return history_value;
   }
 
-  dust::device_array<size_t> &order() {
+  dust::device_array<size_t> &order_swap() {
     return history_order;
+  }
+
+  real_t * value_ptr() {
+    return this->history_value.data() + this->offset_ * this->n_state_ * this->n_particles_;
+  }
+
+  size_t * order_ptr() {
+    return this->history_order.data() + this->offset_ * this->n_particles_;
+  }
+
+  void values_to_host(cuda_stream& stream) {
+    history_value_swap.get_array(value_ptr(), stream, true);
+  }
+
+  void order_to_host(cuda_stream& stream) {
+    history_order_swap.get_array(order_ptr(), stream, true);
   }
 
   template <typename Iterator>
   void history(Iterator ret) const {
     std::vector<real_t> host_history = destride_history();
-    std::vector<size_t> host_order(this->n_particles_ * (this->n_data_ + 1));
-    history_order.get_array(host_order);
-    this->particle_ancestry(ret, host_history.cbegin(), host_order.cbegin());
+    this->particle_ancestry(ret, host_history.cbegin(), this->history_order.cbegin());
   }
 
 private:
-  dust::device_array<real_t> history_value;
-  dust::device_array<size_t> history_order;
+  dust::device_array<real_t> history_value_swap;
+  dust::device_array<size_t> history_order_swap;
+
+#ifdef __NVCC__
+  filter_trajectories_device ( const filter_trajectories_device & ) = delete;
+  filter_trajectories_device ( filter_trajectories_device && ) = delete;
+#endif
 
   std::vector<real_t> destride_history() const {
-    // Copy H->D
-    std::vector<real_t> history_host(size());
-    std::vector<real_t> destride_history(size());
-    history_value.get_array(history_host);
+    std::vector<real_t> blocked_history(size());
     // Destride and copy into iterator
     // TODO openmp here?
     for (size_t i = 0; i < this->n_data_ + 1; ++i) {
       for (size_t j = 0; j < this->n_particles_; ++j) {
         for (size_t k = 0; k < this->n_state_; ++k) {
-          destride_history[i * (this->n_particles_ * this->n_state_) +
-                           j * this->n_state_ +
-                           k] = history_host[i * (this->n_particles_ * this->n_state_) +
-                                             j +
-                                             k * (this->n_particles_)];
+          blocked_history[i * (this->n_particles_ * this->n_state_) +
+                          j * this->n_state_ +
+                          k] = this->history_value[i * (this->n_particles_ * this->n_state_) +
+                                                   j +
+                                                   k * (this->n_particles_)];
         }
       }
     }
-    return destride_history;
+    return blocked_history;
+  }
+
+  void pageable() {
+#ifdef __NVCC__
+    // Make memory pageable again
+    CUDA_CALL_NOTHROW(cudaHostUnregister(this->history_value.data()));
+    CUDA_CALL_NOTHROW(cudaHostUnregister(this->history_order.data()));
+#endif
   }
 };
 

--- a/inst/include/dust/filter_state.hpp
+++ b/inst/include/dust/filter_state.hpp
@@ -182,7 +182,7 @@ private:
   dust::cuda::cuda_stream host_memory_stream_;
 
   std::vector<real_t> destride_history() const {
-    std::vector<real_t> blocked_history(size());
+    std::vector<real_t> blocked_history(this->size());
     // Destride and copy into iterator
     // TODO openmp here?
     for (size_t i = 0; i < this->n_data_ + 1; ++i) {
@@ -275,7 +275,7 @@ public:
     CUDA_CALL(cudaHostRegister(this->state_.data(),
                                this->state_.size() * sizeof(real_t),
                                cudaHostRegisterDefault));
-#else
+#endif
   }
 
   size_t value_offset() {
@@ -293,8 +293,8 @@ public:
   template <typename Iterator>
   void history(Iterator dest) const {
     // Copy from D->H
-    std::vector<real_t> state_host(size());
-    state_.get_array(state_host);
+    std::vector<real_t> state_host(this->size());
+    this->state_.get_array(state_host);
     // Destride and copy into iterator
     // TODO: openmp here? collapse(2)
     for (size_t i = 0; i < this->n_steps_; ++i) {

--- a/inst/include/dust/filter_state.hpp
+++ b/inst/include/dust/filter_state.hpp
@@ -292,9 +292,6 @@ public:
 
   template <typename Iterator>
   void history(Iterator dest) const {
-    // Copy from D->H
-    std::vector<real_t> state_host(this->size());
-    this->state_.get_array(state_host);
     // Destride and copy into iterator
     // TODO: openmp here? collapse(2)
     for (size_t i = 0; i < this->n_steps_; ++i) {
@@ -303,9 +300,9 @@ public:
           *(dest +
             i * (this->n_particles_ * this->n_state_) +
             j * this->n_state_ +
-            k) = state_host[i * (this->n_particles_ * this->n_state_) +
-                            j +
-                            k * (this->n_particles_)];
+            k) = this->state_[i * (this->n_particles_ * this->n_state_) +
+                              j +
+                              k * (this->n_particles_)];
         }
       }
     }

--- a/inst/include/dust/filter_state.hpp
+++ b/inst/include/dust/filter_state.hpp
@@ -138,8 +138,8 @@ public:
     CUDA_CALL(cudaHostRegister(this->history_order.data(),
                                this->history_order.size() * sizeof(real_t),
                                cudaHostRegisterDefault));
-    page_locked = true;
 #endif
+    page_locked = true;
   }
 
   size_t value_offset() {
@@ -209,8 +209,8 @@ private:
       CUDA_CALL_NOTHROW(cudaHostUnregister(this->history_value.data()));
       CUDA_CALL_NOTHROW(cudaHostUnregister(this->history_order.data()));
     }
-    page_locked = false;
 #endif
+    page_locked = false;
   }
 };
 
@@ -287,8 +287,8 @@ public:
     CUDA_CALL(cudaHostRegister(this->state_.data(),
                                this->state_.size() * sizeof(real_t),
                                cudaHostRegisterDefault));
-    page_locked = true;
 #endif
+    page_locked = true;
   }
 
   size_t value_offset() {
@@ -338,10 +338,9 @@ private:
     if (page_locked) {
       CUDA_CALL_NOTHROW(cudaHostUnregister(this->state_.data()));
     }
-    page_locked = false;
 #endif
+    page_locked = false;
   }
-
 };
 
 template <typename real_t>

--- a/inst/include/dust/filter_state.hpp
+++ b/inst/include/dust/filter_state.hpp
@@ -151,18 +151,18 @@ public:
 
   void store_values(dust::device_array<real_t>& state) {
     host_memory_stream_.sync();
-    state.get_array_async(history_value_swap.data(), device_memory_stream_);
+    state.get_array(history_value_swap.data(), device_memory_stream_, true);
     device_memory_stream_.sync();
-    history_value_swap.get_array_async(this->history_value.data() + value_offset(),
-                                       host_memory_stream_);
+    history_value_swap.get_array(this->history_value.data() + value_offset(),
+                                 host_memory_stream_, true);
   }
 
   void store_order(dust::device_array<size_t>& kappa) {
     host_memory_stream_.sync();
-    kappa.get_array_async(history_order_swap.data(), device_memory_stream_);
+    kappa.get_array(history_order_swap.data(), device_memory_stream_, true);
     device_memory_stream_.sync();
-    history_order_swap.get_array_async(this->history_order.data() + order_offset(),
-                                       host_memory_stream_);
+    history_order_swap.get_array(this->history_order.data() + order_offset(),
+                                 host_memory_stream_, true);
   }
 
   template <typename Iterator>
@@ -284,10 +284,10 @@ public:
 
   void store(dust::device_array<real_t>& state) {
     host_memory_stream_.sync();
-    state.get_array_async(state_swap.data(), device_memory_stream_);
+    state.get_array(state_swap.data(), device_memory_stream_, true);
     device_memory_stream_.sync();
-    state_swap.get_array_async(this->state_.data() + value_offset(),
-                               host_memory_stream_);
+    state_swap.get_array(this->state_.data() + value_offset(),
+                         host_memory_stream_, true);
   }
 
   template <typename Iterator>


### PR DESCRIPTION
**Merge after #224**

For larger models, keeping the entire set of history and snapshots in VRAM may be too big. So each cycle I copy these to the host. This is slow (10Gb/s compared to 300Gb/s for D<->D memcpy), so I first copy the current state to a swap space on the device (fast), then complete the slow D->H copy asynchronously while the next step of the filter kernels run.

Async memcpy and kernels requires:
- Pinned host memory (cannot go into swap space). This also increases memcpy speed by around 30-50%.
- Use of the cudaMemcpyAsync API call.
- Use of the non-default stream (see https://developer.nvidia.com/blog/gpu-pro-tip-cuda-7-streams-simplify-concurrency/)

So I have added a stream class to manage the steams, and put everything after initialisation on a non-default stream. This also makes the current async parts a bit clearer (e.g. running the prefix scan while the resample RNGs are drawn and copied).

I believe the current CPUDA tests will hit all of these and test the return is correct, a test on a GPU is just needed to confirm the streams and async copy is working.

TODO:
- [x] Confirmed that async works
- [x] Confirmed that host memory is unpinned before exit
- [ ] Run profile with sircovid to determine whether a CUDA deinterleave/particle ancestry function is needed

Closes #227 

A typical cycle of the filter now looks something like this:
![image](https://user-images.githubusercontent.com/6331837/116433445-6c679380-a841-11eb-86b6-da74961341f8.png)
