### PR TITLE
More robust resampling

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dust
 Title: Iterate Multiple Realisations of Stochastic Models
-Version: 0.9.4
+Version: 0.9.5
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("John", "Lees", role = "aut"),

--- a/inst/include/dust/filter_tools.hpp
+++ b/inst/include/dust/filter_tools.hpp
@@ -14,14 +14,15 @@ void resample_weight(typename std::vector<real_t>::const_iterator w,
   const real_t tot = std::accumulate(w, w + n, static_cast<real_t>(0));
   real_t ww = 0.0, uu0 = tot * u / n, du = tot / n;
   size_t j = offset;
+  const size_t end = n + offset;
   for (size_t i = 0; i < n; ++i) {
     // We could accumulate uu by adding du at each iteration but that
     // suffers roundoff error here with floats.
     const real_t uu = uu0 + i * du;
-    // The second clause should never be hit but prevents any invalid
-    // read if we have pathalogical 'u' that is within floating point
-    // eps of 1
-    while (ww < uu && j < n) {
+    // The second clause (i.e., j - offset < n) should never be hit
+    // but prevents any invalid read if we have pathalogical 'u' that
+    // is within floating point eps of 1
+    while (ww < uu && j < end) {
       ww += *w;
       ++w;
       ++j;

--- a/inst/include/dust/filter_tools.hpp
+++ b/inst/include/dust/filter_tools.hpp
@@ -12,16 +12,20 @@ void resample_weight(typename std::vector<real_t>::const_iterator w,
                      size_t n, real_t u, size_t offset,
                      typename std::vector<size_t>::iterator idx) {
   const real_t tot = std::accumulate(w, w + n, static_cast<real_t>(0));
-  real_t ww = 0.0, uu = tot * u / n, du = tot / n;
-
+  real_t ww = 0.0, uu0 = tot * u / n, du = tot / n;
   size_t j = offset;
   for (size_t i = 0; i < n; ++i) {
-    while (ww < uu) {
+    // We could accumulate uu by adding du at each iteration but that
+    // suffers roundoff error here with floats.
+    const real_t uu = uu0 * i * du;
+    // The second clause should never be hit but prevents any invalid
+    // read if we have pathalogical 'u' that is within floating point
+    // eps of 1
+    while (ww < uu && j < n) {
       ww += *w;
       ++w;
       ++j;
     }
-    uu += du;
     *idx = j == 0 ? 0 : j - 1;
     ++idx;
   }

--- a/inst/include/dust/filter_tools.hpp
+++ b/inst/include/dust/filter_tools.hpp
@@ -17,7 +17,7 @@ void resample_weight(typename std::vector<real_t>::const_iterator w,
   for (size_t i = 0; i < n; ++i) {
     // We could accumulate uu by adding du at each iteration but that
     // suffers roundoff error here with floats.
-    const real_t uu = uu0 * i * du;
+    const real_t uu = uu0 + i * du;
     // The second clause should never be hit but prevents any invalid
     // read if we have pathalogical 'u' that is within floating point
     // eps of 1


### PR DESCRIPTION
This PR fixes an issue in the resampling when using `float` (rather than `double`). Only seemed to affect things when we drew a very large `u`.

See https://github.com/reside-ic/reside-ic.github.io/pull/60 for details

Fixes #237 