### PR TITLE
Avoid precision loss in dnbinom

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dust
 Title: Iterate Multiple Realisations of Stochastic Models
-Version: 0.9.5
+Version: 0.9.6
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("John", "Lees", role = "aut"),

--- a/R/cpp11.R
+++ b/R/cpp11.R
@@ -8,8 +8,8 @@ dust_dnorm <- function(x, mu, sd, log) {
   .Call(`_dust_dust_dnorm`, x, mu, sd, log)
 }
 
-dust_dnbinom <- function(x, size, mu, log) {
-  .Call(`_dust_dust_dnbinom`, x, size, mu, log)
+dust_dnbinom <- function(x, size, mu, log, is_float) {
+  .Call(`_dust_dust_dnbinom`, x, size, mu, log, is_float)
 }
 
 dust_dbetabinom <- function(x, size, prob, rho, log) {

--- a/inst/include/dust/densities.hpp
+++ b/inst/include/dust/densities.hpp
@@ -81,7 +81,6 @@ HOSTDEVICE T dnbinom(int x, T size, T mu, bool log) {
   static_assert(std::is_floating_point<T>::value,
                 "dnbinom should only be used with real types");
 #endif
-  const T prob = size / (size + mu);
   if (x == 0 && size == 0) {
     return maybe_log(0, log);
   }
@@ -91,11 +90,24 @@ HOSTDEVICE T dnbinom(int x, T size, T mu, bool log) {
   if (mu == 0) {
     return maybe_log(x == 0 ? 0 : -dust::utils::infinity<T>(), log);
   }
-  const T ret = dust::utils::lgamma(static_cast<T>(x + size)) -
-    dust::utils::lgamma(static_cast<T>(size)) -
-    dust::utils::lgamma(static_cast<T>(x + 1)) +
-    size * std::log(prob) + x * std::log(1 - prob);
-  return maybe_log(ret, log);
+
+  // Avoid size / (size + mu) where this would cause prob to be
+  // equal. Somewhat arbitrarily, taking 100 * floating point eps as
+  // the change over.
+  const T ratio = dust::utils::epsilon<T>() * 100;
+  if (mu < ratio * size) {
+    const T p = std::log(mu / (1 + mu / size));
+    const T ret = x * p - mu - lgamma(x + 1) +
+      std::log1p(x * (x - 1) / (2 * size));
+    return maybe_log(ret, log);
+  } else {
+    const T prob = size / (size + mu);
+    const T ret = dust::utils::lgamma(static_cast<T>(x + size)) -
+      dust::utils::lgamma(static_cast<T>(size)) -
+      dust::utils::lgamma(static_cast<T>(x + 1)) +
+      size * std::log(prob) + x * std::log(1 - prob);
+    return maybe_log(ret, log);
+  }
 }
 
 // A note on this parametrisation:

--- a/inst/include/dust/densities.hpp
+++ b/inst/include/dust/densities.hpp
@@ -91,8 +91,8 @@ HOSTDEVICE T dnbinom(int x, T size, T mu, bool log) {
     return maybe_log(x == 0 ? 0 : -dust::utils::infinity<T>(), log);
   }
 
-  // Avoid size / (size + mu) where this would cause prob to be
-  // equal. Somewhat arbitrarily, taking 100 * floating point eps as
+  // Avoid size / (size + mu) when size is close to zero, and this would cause prob to be
+  // equal to zero. Somewhat arbitrarily, taking 100 * floating point eps as
   // the change over.
   const T ratio = dust::utils::epsilon<T>() * 100;
   if (mu < ratio * size) {

--- a/inst/include/dust/densities.hpp
+++ b/inst/include/dust/densities.hpp
@@ -96,8 +96,8 @@ HOSTDEVICE T dnbinom(int x, T size, T mu, bool log) {
   // the change over.
   const T ratio = dust::utils::epsilon<T>() * 100;
   if (mu < ratio * size) {
-    const T p = std::log(mu / (1 + mu / size));
-    const T ret = x * p - mu - lgamma(x + 1) +
+    const T log_prob = std::log(mu / (1 + mu / size));
+    const T ret = x * log_prob - mu - lgamma(x + 1) +
       std::log1p(x * (x - 1) / (2 * size));
     return maybe_log(ret, log);
   } else {

--- a/src/cpp11.cpp
+++ b/src/cpp11.cpp
@@ -19,10 +19,10 @@ extern "C" SEXP _dust_dust_dnorm(SEXP x, SEXP mu, SEXP sd, SEXP log) {
   END_CPP11
 }
 // densities.cpp
-SEXP dust_dnbinom(cpp11::integers x, cpp11::doubles size, cpp11::doubles mu, bool log);
-extern "C" SEXP _dust_dust_dnbinom(SEXP x, SEXP size, SEXP mu, SEXP log) {
+SEXP dust_dnbinom(cpp11::integers x, cpp11::doubles size, cpp11::doubles mu, bool log, bool is_float);
+extern "C" SEXP _dust_dust_dnbinom(SEXP x, SEXP size, SEXP mu, SEXP log, SEXP is_float) {
   BEGIN_CPP11
-    return cpp11::as_sexp(dust_dnbinom(cpp11::as_cpp<cpp11::decay_t<cpp11::integers>>(x), cpp11::as_cpp<cpp11::decay_t<cpp11::doubles>>(size), cpp11::as_cpp<cpp11::decay_t<cpp11::doubles>>(mu), cpp11::as_cpp<cpp11::decay_t<bool>>(log)));
+    return cpp11::as_sexp(dust_dnbinom(cpp11::as_cpp<cpp11::decay_t<cpp11::integers>>(x), cpp11::as_cpp<cpp11::decay_t<cpp11::doubles>>(size), cpp11::as_cpp<cpp11::decay_t<cpp11::doubles>>(mu), cpp11::as_cpp<cpp11::decay_t<bool>>(log), cpp11::as_cpp<cpp11::decay_t<bool>>(is_float)));
   END_CPP11
 }
 // densities.cpp
@@ -849,7 +849,7 @@ extern SEXP _dust_cpp_openmp_info();
 extern SEXP _dust_cpp_scale_log_weights(SEXP);
 extern SEXP _dust_dust_dbetabinom(SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP _dust_dust_dbinom(SEXP, SEXP, SEXP, SEXP);
-extern SEXP _dust_dust_dnbinom(SEXP, SEXP, SEXP, SEXP);
+extern SEXP _dust_dust_dnbinom(SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP _dust_dust_dnorm(SEXP, SEXP, SEXP, SEXP);
 extern SEXP _dust_dust_dpois(SEXP, SEXP, SEXP);
 extern SEXP _dust_dust_rng_alloc(SEXP, SEXP, SEXP);
@@ -969,7 +969,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_dust_cpp_scale_log_weights",         (DL_FUNC) &_dust_cpp_scale_log_weights,         1},
     {"_dust_dust_dbetabinom",               (DL_FUNC) &_dust_dust_dbetabinom,               5},
     {"_dust_dust_dbinom",                   (DL_FUNC) &_dust_dust_dbinom,                   4},
-    {"_dust_dust_dnbinom",                  (DL_FUNC) &_dust_dust_dnbinom,                  4},
+    {"_dust_dust_dnbinom",                  (DL_FUNC) &_dust_dust_dnbinom,                  5},
     {"_dust_dust_dnorm",                    (DL_FUNC) &_dust_dust_dnorm,                    4},
     {"_dust_dust_dpois",                    (DL_FUNC) &_dust_dust_dpois,                    3},
     {"_dust_dust_rng_alloc",                (DL_FUNC) &_dust_dust_rng_alloc,                3},

--- a/src/densities.cpp
+++ b/src/densities.cpp
@@ -24,15 +24,25 @@ SEXP dust_dnorm(cpp11::doubles x, cpp11::doubles mu, cpp11::doubles sd,
   return ret;
 }
 
-[[cpp11::register]]
-SEXP dust_dnbinom(cpp11::integers x, cpp11::doubles size, cpp11::doubles mu,
-                  bool log) {
+template <typename T>
+SEXP dust_dnbinom_(cpp11::integers x, cpp11::doubles size, cpp11::doubles mu,
+                   bool log) {
   const size_t n = x.size();
   cpp11::writable::doubles ret(x.size());
   for (size_t i = 0; i < n; ++i) {
-    ret[i] = dust::dnbinom<double>(x[i], size[i], mu[i], log);
+    ret[i] = dust::dnbinom<T>(x[i], size[i], mu[i], log);
   }
   return ret;
+}
+
+
+[[cpp11::register]]
+SEXP dust_dnbinom(cpp11::integers x, cpp11::doubles size, cpp11::doubles mu,
+                  bool log, bool is_float) {
+  return is_float ?
+    dust_dnbinom_<float>(x, size, mu, log) :
+    dust_dnbinom_<double>(x, size, mu, log);
+
 }
 
 [[cpp11::register]]

--- a/src/densities.cpp
+++ b/src/densities.cpp
@@ -42,7 +42,6 @@ SEXP dust_dnbinom(cpp11::integers x, cpp11::doubles size, cpp11::doubles mu,
   return is_float ?
     dust_dnbinom_<float>(x, size, mu, log) :
     dust_dnbinom_<double>(x, size, mu, log);
-
 }
 
 [[cpp11::register]]

--- a/tests/testthat/test-densities.R
+++ b/tests/testthat/test-densities.R
@@ -52,64 +52,83 @@ test_that("dbinom agrees", {
 
 
 test_that("dnbinom agrees", {
-  size <- as.numeric(1:50)
-  prob <- runif(length(size))
-  mu <- size * (1 - prob) / prob
-  x <- as.integer(sample(size, replace = TRUE))
-  expect_equal(dust_dnbinom(x, size, mu, TRUE),
-               dnbinom(x, size, mu = mu, log = TRUE))
-  expect_equal(dust_dnbinom(x, size, mu, FALSE),
-               dnbinom(x, size, mu = mu, log = FALSE))
+  for (is_float in c(FALSE, TRUE)) {
+    if (is_float) {
+      tolerance <- sqrt(sqrt(.Machine$double.eps))
+    } else {
+      tolerance <- sqrt(.Machine$double.eps)
+    }
 
-  ## size > x case which was implemented incorrectly in <= v0.6.5
-  expect_equal(
-    dnbinom(511, 2, mu = 6.65, log = TRUE),
-    dust_dnbinom(511L, 2, 6.65, TRUE))
+    size <- as.numeric(1:50)
+    prob <- runif(length(size))
+    mu <- size * (1 - prob) / prob
+    x <- as.integer(sample(size, replace = TRUE))
+    expect_equal(dust_dnbinom(x, size, mu, TRUE, is_float),
+                 dnbinom(x, size, mu = mu, log = TRUE),
+                 tolerance = tolerance)
+    expect_equal(dust_dnbinom(x, size, mu, FALSE, is_float),
+                 dnbinom(x, size, mu = mu, log = FALSE),
+                 tolerance = tolerance)
 
-  ## Allow non integer size (wrong in <= 0.7.5)
-  expect_equal(
-    dust_dnbinom(x = 511L, size = 3.5, mu = 1, log = TRUE),
-    dnbinom(511, 3.5, mu = 1, log = TRUE))
+    ## size > x case which was implemented incorrectly in <= v0.6.5
+    expect_equal(
+      dnbinom(511, 2, mu = 6.65, log = TRUE),
+      dust_dnbinom(511L, 2, 6.65, TRUE, is_float),
+      tolerance = tolerance)
 
-  ## Corner cases
-  expect_equal(dust_dnbinom(0L, 0, 0, TRUE),
-               dnbinom(0, 0, mu = 0, log = TRUE))
-  expect_equal(dust_dnbinom(0L, 0, 0, FALSE),
-               dnbinom(0, 0, mu = 0, log = FALSE))
-  expect_equal(dust_dnbinom(0L, 0, 0.5, FALSE),
-               dnbinom(0, 0, mu = 0.5, log = FALSE))
-  expect_equal(dust_dnbinom(10L, 0, 1, TRUE),
-               suppressWarnings(dnbinom(10L, 0L, mu = 1, log = TRUE)))
-  expect_equal(dust_dnbinom(10L, 1, 1, TRUE),
-               dnbinom(10L, 1L, mu = 1, log = TRUE))
-  expect_equal(dust_dnbinom(10L, 0, 1, FALSE),
-               suppressWarnings(dnbinom(10L, 0L, mu = 1, log = FALSE)))
-  expect_equal(dust_dnbinom(0L, 10, 1, TRUE),
-               suppressWarnings(dnbinom(0L, 10L, mu = 1, log = TRUE)))
-  ## We disagree with R here; we *could* return NaN but -Inf seems
-  ## more sensible, and is what R returns if mu = eps
-  expect_equal(dust_dnbinom(10L, 0, 0, TRUE), -Inf)
+    ## Allow non integer size (wrong in <= 0.7.5)
+    expect_equal(
+      dust_dnbinom(511L, 3.5, 1, TRUE, is_float),
+      dnbinom(511, 3.5, mu = 1, log = TRUE),
+      tolerance = tolerance)
 
-  expect_equal(
-    dust_dnbinom(x = 0L, size = 2, mu = 0, log = TRUE),
-    dnbinom(x = 0, size = 2, mu = 0, log = TRUE))
-  expect_equal(
-    dust_dnbinom(x = 0L, size = 2, mu = 0, log = FALSE),
-    dnbinom(x = 0, size = 2, mu = 0, log = FALSE))
-  expect_equal(
-    dust_dnbinom(x = 1L, size = 2, mu = 0, log = TRUE),
-    dnbinom(x = 1, size = 2, mu = 0, log = TRUE))
-  expect_equal(
-    dust_dnbinom(x = 1L, size = 2, mu = 0, log = FALSE),
-    dnbinom(x = 1, size = 2, mu = 0, log = FALSE))
+    ## Corner cases
+    expect_equal(dust_dnbinom(0L, 0, 0, TRUE, is_float),
+                 dnbinom(0, 0, mu = 0, log = TRUE))
+    expect_equal(dust_dnbinom(0L, 0, 0, FALSE, is_float),
+                 dnbinom(0, 0, mu = 0, log = FALSE))
+    expect_equal(dust_dnbinom(0L, 0, 0.5, FALSE, is_float),
+                 dnbinom(0, 0, mu = 0.5, log = FALSE))
+    expect_equal(dust_dnbinom(10L, 0, 1, TRUE, is_float),
+                 suppressWarnings(dnbinom(10L, 0L, mu = 1, log = TRUE)))
+    expect_equal(dust_dnbinom(10L, 1, 1, TRUE, is_float),
+                 dnbinom(10L, 1L, mu = 1, log = TRUE))
+    expect_equal(dust_dnbinom(10L, 0, 1, FALSE, is_float),
+                 suppressWarnings(dnbinom(10L, 0L, mu = 1, log = FALSE)))
+    expect_equal(dust_dnbinom(0L, 10, 1, TRUE, is_float),
+                 suppressWarnings(dnbinom(0L, 10L, mu = 1, log = TRUE)),
+                 tolerance = tolerance)
+    ## We disagree with R here; we *could* return NaN but -Inf seems
+    ## more sensible, and is what R returns if mu = eps
+    expect_equal(dust_dnbinom(10L, 0, 0, TRUE, is_float), -Inf)
 
-  ## Special case where mu is zero
-  expect_equal(
-    dnbinom(34, 2, mu = 0, log = TRUE),
-    dust_dnbinom(34L, 2, 0, TRUE))
-  expect_equal(
-    dnbinom(34, 2, mu = 0, log = FALSE),
-    dust_dnbinom(34L, 2, 0, FALSE))
+    expect_equal(
+      dust_dnbinom(x = 0L, size = 2, mu = 0, log = TRUE, is_float = is_float),
+      dnbinom(x = 0, size = 2, mu = 0, log = TRUE))
+    expect_equal(
+      dust_dnbinom(x = 0L, size = 2, mu = 0, log = FALSE, is_float = is_float),
+      dnbinom(x = 0, size = 2, mu = 0, log = FALSE))
+    expect_equal(
+      dust_dnbinom(x = 1L, size = 2, mu = 0, log = TRUE, is_float = is_float),
+      dnbinom(x = 1, size = 2, mu = 0, log = TRUE))
+    expect_equal(
+      dust_dnbinom(x = 1L, size = 2, mu = 0, log = FALSE, is_float = is_float),
+      dnbinom(x = 1, size = 2, mu = 0, log = FALSE))
+
+    ## Special case where mu is zero
+    expect_equal(
+      dnbinom(34, 2, mu = 0, log = TRUE),
+      dust_dnbinom(34L, 2, 0, TRUE, is_float))
+    expect_equal(
+      dnbinom(34, 2, mu = 0, log = FALSE),
+      dust_dnbinom(34L, 2, 0, FALSE, is_float))
+
+    ## Special case of mu << size
+    expect_equal(dust_dnbinom(0L, 50, 1e-8, TRUE, is_float),
+                 dnbinom(0L, size = 50, mu = 1e-8, log = TRUE))
+    expect_equal(dust_dnbinom(0L, 50, 1e-20, TRUE, is_float),
+                 dnbinom(0L, size = 50, mu = 1e-20, log = TRUE))
+  }
 })
 
 


### PR DESCRIPTION
Seen while running sircovid in float mode on real data, where we hit a point with zero modelled + zero observed deaths.

Fixes #239 
