### PR TITLE
Rejoin after divergences in kernel functions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dust
 Title: Iterate Multiple Realisations of Stochastic Models
-Version: 0.9.6
+Version: 0.9.7
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("John", "Lees", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # dust 0.9.7
 
-* Synchronise possible divergences in the density functions (CUDA only) (#242)
+* Synchronise possible divergences in the density functions (CUDA only) (#243)
 
 # dust 0.9.6
 
@@ -10,6 +10,7 @@
 
 * Fix a bug when running the systematic resample in the particle filter
 in float mode (#238)
+
 # dust 0.9.4
 
 * Fix a bug when running the CUDA version of the particle filter without

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,15 @@
+# dust 0.9.7
+
+* Synchronise possible divergences in the density functions (CUDA only) (#242)
+
+# dust 0.9.6
+
+* Fix a possible issue with dnbinom in float mode with a small mean (#240)
+
+# dust 0.9.5
+
+* Fix a bug when running the systematic resample in the particle filter
+in float mode (#238)
 # dust 0.9.4
 
 * Fix a bug when running the CUDA version of the particle filter without

--- a/inst/include/dust/cuda.cuh
+++ b/inst/include/dust/cuda.cuh
@@ -8,7 +8,6 @@
 #define HOSTDEVICE __host__ __device__
 #define KERNEL __global__
 #define ALIGN(n) __align__(n)
-#define SYNCWARP __syncwarp();
 
 // This is necessary due to templates which are __host__ __device__;
 // whenever a HOSTDEVICE function is called from another HOSTDEVICE
@@ -37,14 +36,15 @@
 #undef DUST_CUDA_ENABLE_PROFILER
 #define __nv_exec_check_disable__
 #define ALIGN(n)
-#define SYNCWARP
 #endif
 
 // const definition depends on __host__/__device__
 #ifdef __CUDA_ARCH__
 #define CONSTANT __constant__
+#define SYNCWARP __syncwarp();
 #else
 #define CONSTANT const
+#define SYNCWARP
 #endif
 
 namespace dust {

--- a/inst/include/dust/cuda.cuh
+++ b/inst/include/dust/cuda.cuh
@@ -8,6 +8,7 @@
 #define HOSTDEVICE __host__ __device__
 #define KERNEL __global__
 #define ALIGN(n) __align__(n)
+#define SYNCWARP __syncwarp();
 
 // This is necessary due to templates which are __host__ __device__;
 // whenever a HOSTDEVICE function is called from another HOSTDEVICE
@@ -36,6 +37,7 @@
 #undef DUST_CUDA_ENABLE_PROFILER
 #define __nv_exec_check_disable__
 #define ALIGN(n)
+#define SYNCWARP
 #endif
 
 // const definition depends on __host__/__device__

--- a/inst/include/dust/densities.hpp
+++ b/inst/include/dust/densities.hpp
@@ -75,16 +75,17 @@ template <typename T>
 HOSTDEVICE T dnorm(T x, T mu, T sd, bool log) {
   T ret;
   if (sd == 0) {
-    ret = ddelta(x - mu, log);
+    ret = ddelta(x - mu, log); // This does maybe_log
   } else {
     const T dx = x - mu;
     ret = - dx * dx / (2 * sd * sd) - norm_integral<T>() - std::log(sd);
+    ret = maybe_log(ret, log);
   }
 
 #ifdef __CUDA_ARCH__
   __syncwarp();
 #endif
-  return maybe_log(ret, log);
+  return ret;
 }
 
 template <typename T>

--- a/inst/include/dust/densities.hpp
+++ b/inst/include/dust/densities.hpp
@@ -109,7 +109,7 @@ HOSTDEVICE T dnbinom(int x, T size, T mu, bool log) {
     const T ratio = dust::utils::epsilon<T>() * 100;
     if (mu < ratio * size) {
       const T log_prob = std::log(mu / (1 + mu / size));
-      ret = x * log_prob - mu - std::utils::lgamma(x + 1) +
+      ret = x * log_prob - mu - dust::utils::lgamma(x + 1) +
         std::log1p(x * (x - 1) / (2 * size));
     } else {
       const T prob = size / (size + mu);

--- a/inst/include/dust/densities.hpp
+++ b/inst/include/dust/densities.hpp
@@ -110,7 +110,7 @@ HOSTDEVICE T dnbinom(int x, T size, T mu, bool log) {
     const T ratio = dust::utils::epsilon<T>() * 100;
     if (mu < ratio * size) {
       const T log_prob = std::log(mu / (1 + mu / size));
-      ret = x * log_prob - mu - dust::utils::lgamma(x + 1) +
+      ret = x * log_prob - mu - dust::utils::lgamma(static_cast<T>(x + 1)) +
         std::log1p(x * (x - 1) / (2 * size));
     } else {
       const T prob = size / (size + mu);

--- a/inst/include/dust/densities.hpp
+++ b/inst/include/dust/densities.hpp
@@ -54,7 +54,7 @@ HOSTDEVICE T dbinom(int x, int size, T prob, bool log) {
   if (x == 0 && size == 0) {
     ret = 0;
   } else {
-    const T ret = lchoose<T>(size, x) +
+    ret = lchoose<T>(size, x) +
       x * std::log(prob) +
       (size - x) * std::log(1 - prob);
   }
@@ -163,7 +163,7 @@ HOSTDEVICE T dpois(int x, T lambda, bool log) {
   if (x == 0 && lambda == 0) {
     ret = 0;
   } else {
-    const T ret = x * std::log(lambda) - lambda -
+    ret = x * std::log(lambda) - lambda -
       dust::utils::lgamma(static_cast<T>(x + 1));
   }
 

--- a/inst/include/dust/densities.hpp
+++ b/inst/include/dust/densities.hpp
@@ -59,9 +59,7 @@ HOSTDEVICE T dbinom(int x, int size, T prob, bool log) {
       (size - x) * std::log(1 - prob);
   }
 
-#ifdef __CUDA_ARCH__
-  __syncwarp();
-#endif
+  SYNCWARP
   return maybe_log(ret, log);
 }
 
@@ -82,9 +80,7 @@ HOSTDEVICE T dnorm(T x, T mu, T sd, bool log) {
     ret = maybe_log(ret, log);
   }
 
-#ifdef __CUDA_ARCH__
-  __syncwarp();
-#endif
+  SYNCWARP
   return ret;
 }
 
@@ -121,9 +117,7 @@ HOSTDEVICE T dnbinom(int x, T size, T mu, bool log) {
     }
   }
 
-#ifdef __CUDA_ARCH__
-  __syncwarp();
-#endif
+  SYNCWARP
   return maybe_log(ret, log);
 }
 
@@ -148,9 +142,7 @@ HOSTDEVICE T dbetabinom(int x, int size, T prob, T rho, bool log) {
     ret = lchoose<T>(size, x) + lbeta(x + a, size - x + b) - lbeta(a, b);
   }
 
-#ifdef __CUDA_ARCH__
-  __syncwarp();
-#endif
+  SYNCWARP
   return maybe_log(ret, log);
 }
 
@@ -168,9 +160,7 @@ HOSTDEVICE T dpois(int x, T lambda, bool log) {
       dust::utils::lgamma(static_cast<T>(x + 1));
   }
 
-#ifdef __CUDA_ARCH__
-  __syncwarp();
-#endif
+  SYNCWARP
   return maybe_log(ret, log);
 }
 

--- a/inst/include/dust/distr/binomial.hpp
+++ b/inst/include/dust/distr/binomial.hpp
@@ -205,10 +205,7 @@ HOSTDEVICE int rbinom(rng_state_t<real_t>& rng_state, int n,
     }
   }
 
-#ifdef __CUDA_ARCH__
-  __syncwarp();
-#endif
-
+  SYNCWARP
   return draw;
 }
 

--- a/inst/include/dust/distr/normal.hpp
+++ b/inst/include/dust/distr/normal.hpp
@@ -22,6 +22,9 @@ HOSTDEVICE inline real_t box_muller(rng_state_t<real_t>& rng_state) {
     u2 = dust::unif_rand(rng_state);
   } while (u1 <= epsilon);
 
+#ifdef __CUDA_ARCH__
+  __syncwarp();
+#endif
   return std::sqrt(-2 * std::log(u1)) * std::cos(two_pi * u2);
 }
 

--- a/inst/include/dust/distr/normal.hpp
+++ b/inst/include/dust/distr/normal.hpp
@@ -22,9 +22,7 @@ HOSTDEVICE inline real_t box_muller(rng_state_t<real_t>& rng_state) {
     u2 = dust::unif_rand(rng_state);
   } while (u1 <= epsilon);
 
-#ifdef __CUDA_ARCH__
-  __syncwarp();
-#endif
+  SYNCWARP
   return std::sqrt(-2 * std::log(u1)) * std::cos(two_pi * u2);
 }
 

--- a/inst/include/dust/distr/poisson.hpp
+++ b/inst/include/dust/distr/poisson.hpp
@@ -111,6 +111,10 @@ HOSTDEVICE int rpois(rng_state_t<real_t>& rng_state,
       }
     }
   }
+
+#ifdef __CUDA_ARCH__
+  __syncwarp();
+#endif
   return x;
 }
 

--- a/inst/include/dust/distr/poisson.hpp
+++ b/inst/include/dust/distr/poisson.hpp
@@ -112,9 +112,7 @@ HOSTDEVICE int rpois(rng_state_t<real_t>& rng_state,
     }
   }
 
-#ifdef __CUDA_ARCH__
-  __syncwarp();
-#endif
+  SYNCWARP
   return x;
 }
 

--- a/inst/include/dust/kernels.hpp
+++ b/inst/include/dust/kernels.hpp
@@ -143,9 +143,8 @@ KERNEL void run_particles(size_t step_start,
                        shared_state.shared_real,
                        rng_block,
                        p_state_next);
-#ifdef __CUDA_ARCH__
-      __syncwarp();
-#endif
+      SYNCWARP
+
       dust::interleaved<real_t> tmp = p_state;
       p_state = p_state_next;
       p_state_next = tmp;
@@ -228,9 +227,7 @@ KERNEL void compare_particles(size_t n_particles,
                                    shared_state.shared_int,
                                    shared_state.shared_real,
                                    rng_block);
-#ifdef __CUDA_ARCH__
-    __syncwarp();
-#endif
+    SYNCWARP
     dust::put_rng_state(rng_block, p_rng);
   }
 }
@@ -252,9 +249,7 @@ DEVICE size_t binary_interval_search(const T * array,
       r_pivot = m;
     }
   }
-#ifdef __CUDA_ARCH__
-  __syncwarp();
-#endif
+  SYNCWARP
   return l_pivot;
 }
 

--- a/inst/include/dust/kernels.hpp
+++ b/inst/include/dust/kernels.hpp
@@ -229,7 +229,6 @@ KERNEL void compare_particles(size_t n_particles,
                                    shared_state.shared_real,
                                    rng_block);
 #ifdef __CUDA_ARCH__
-    // Branching unlikely in compare_device, but just in case
     __syncwarp();
 #endif
     dust::put_rng_state(rng_block, p_rng);

--- a/inst/include/dust/utils.hpp
+++ b/inst/include/dust/utils.hpp
@@ -143,6 +143,8 @@ HOSTDEVICE real_t lgamma(real_t x) {
 #ifdef __CUDA_ARCH__
   return lgamma_nvcc(x);
 #else
+  static_assert(std::is_floating_point<real_t>::value,
+                "lgamma should only be used with real types");
   return std::lgamma(x);
 #endif
 }


### PR DESCRIPTION
This was mostly checked in rbinom before, but this applies those findings across the r<dist> and d<dist> functions. This is only needed with branching (if/break/continue/until) in KERNEL, DEVICE or HOSTDEVICE functions, so I think this covers all of those.