### PR TITLE
Fix another float issue

### DIFF
--- a/.github/workflows/version-check.yaml
+++ b/.github/workflows/version-check.yaml
@@ -1,0 +1,24 @@
+on:
+  pull_request:
+    branches:
+      - master
+      - main
+
+name: Version Check
+
+jobs:
+  all:
+    runs-on: ubuntu-20.04
+
+    name: Version Check
+
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - uses: actions/checkout@v2.1.1
+        with:
+          fetch-depth: 0
+
+      - name: Check version format and availability
+        run: ./scripts/version_check

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dust
 Title: Iterate Multiple Realisations of Stochastic Models
-Version: 0.9.7
+Version: 0.9.8
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("John", "Lees", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# dust 0.9.8
+
+* Fix infinite loop with rbinom using floats
+
 # dust 0.9.7
 
 * Synchronise possible divergences in the density functions (CUDA only) (#243)

--- a/inst/include/dust/distr/binomial.hpp
+++ b/inst/include/dust/distr/binomial.hpp
@@ -43,7 +43,7 @@ real_t HOSTDEVICE binomial_inversion_calc(real_t u, int n, real_t p) {
     u -= f;
     k++;
     f *= (g / k - r);
-    if (f == f_prev) {
+    if (f == f_prev || k > n) {
       // This catches an issue seen running with floats where we end
       // up unable to decrease 'f' because we've run out of
       // precision. In this case we'll try again with a better u

--- a/inst/template/Makevars.cuda
+++ b/inst/template/Makevars.cuda
@@ -4,8 +4,11 @@ OBJECTS = cpp11.o dust.o
 PKG_LIBS = {{cuda$lib_flags}} -lcudart $(SHLIB_OPENMP_CXXFLAGS)
 PKG_CXXFLAGS=-I{{path_dust_include}} -DHAVE_INLINE $(SHLIB_OPENMP_CXXFLAGS)
 
+# NOTE: using -Xcompiler -fopenmp here to pass this to the underlying
+# compiler, but this is not as portable as using
+# $(SHLIB_OPENMP_CXXFLAGS)
 NVCC = nvcc
-NVCC_FLAGS = -std=c++14 {{cuda$nvcc_flags}} -I. -I$(R_INCLUDE_DIR) -I{{path_dust_include}} {{cuda$cub_include}} $(CLINK_CPPFLAGS) {{cuda$gencode}} -Xcompiler -fPIC -x cu
+NVCC_FLAGS = -std=c++14 {{cuda$nvcc_flags}} -I. -I$(R_INCLUDE_DIR) -I{{path_dust_include}} {{cuda$cub_include}} $(CLINK_CPPFLAGS) {{cuda$gencode}} -Xcompiler -fPIC -Xcompiler -fopenmp -x cu
 
 %.o: %.cu
 	$(NVCC) $(NVCC_FLAGS) -c $< -o $@

--- a/scripts/version_check
+++ b/scripts/version_check
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -e
+# Usage:
+#   check_version [<version>]
+#
+# If version is not given as a positional argument, then we'll read it
+# from the DESCRIPTION file.
+#
+# We assume that a version already exists as a tag.
+VERSION=${1:-$(grep '^Version' DESCRIPTION  | sed 's/.*: *//')}
+TAG="v${VERSION}"
+
+echo "Proposed version number '$VERSION'"
+
+if echo "$VERSION" | grep -Eq "[0-9]+[.][0-9]+[.][0-9]+"; then
+    echo "Version number in correct format"
+else
+    echo "Invalid format version number '$VERSION' must be in format 'x.y.z'"
+    exit 1
+    echo "not found"
+fi
+
+echo "Updating remote git data"
+git fetch
+
+if git rev-parse "$TAG" >/dev/null 2>&1; then
+    echo "Tag $TAG already exists - update version number"
+    exit 1
+else
+    echo "Version number not yet present as git tag"
+fi
+
+MAJOR=$(echo $VERSION | cut -d. -f1)
+MINOR=$(echo $VERSION | cut -d. -f2)
+PATCH=$(echo $VERSION | cut -d. -f3)
+
+BRANCH_DEFAULT=$(git remote show origin | awk '/HEAD branch/ {print $NF}')
+LAST_TAG=$(git describe --tags --abbrev=0 "origin/${BRANCH_DEFAULT}")
+LAST_VERSION=$(echo "$LAST_TAG" | sed 's/^v//')
+LAST_MAJOR=$(echo $LAST_VERSION | cut -d. -f1)
+LAST_MINOR=$(echo $LAST_VERSION | cut -d. -f2)
+LAST_PATCH=$(echo $LAST_VERSION | cut -d. -f3)
+
+if (( $MAJOR > $LAST_MAJOR )); then
+    echo "Increasing MAJOR version"
+    exit 0
+elif (( $MINOR > $LAST_MINOR )); then
+    echo "Increasing MINOR version"
+    exit 0
+elif (( $PATCH > $LAST_PATCH )); then
+    echo "Increasing PATCH version"
+    exit 0
+else
+    echo "Version number has not increased relative to $LAST_VERSION"
+    exit 1
+fi

--- a/tests/testthat/test-rng.R
+++ b/tests/testthat/test-rng.R
@@ -438,6 +438,20 @@ test_that("binomial random numbers from floats have correct distribution", {
 })
 
 
+test_that("special case", {
+  ## This has been fairly carefully selected; with this set of
+  ## parameters we get one infinite loop in dust 0.9.7
+  m <- 1000000
+  n <- 6
+  p <- 0.449999988
+  yf <- dust_rng$new(1, 1, "float")$rbinom(m, n, p)
+  yd <- dust_rng$new(1, 1, "double")$rbinom(m, n, p)
+
+  expect_equal(mean(yf), mean(yd), tolerance = 1e-5)
+  expect_equal(var(yf), var(yd), tolerance = 1e-4)
+})
+
+
 test_that("binomial random numbers from floats have correct distribution", {
   m <- 100000
   n <- 100L


### PR DESCRIPTION
Fixes another nasty case with floats. Minimal example:

```
#include <iostream>
#include <dust/cuda.cuh>
#include <dust/rng.hpp>
#include <dust/distr/binomial.hpp>

int main() {
  const float u = 0.999999702;
  const float p = 0.449999988;
  const int n = 6;
  
  std::cout << "float " << dust::distr::binomial_inversion_calc<float>(u, n, p) <<
    std::endl;

  return 0;
}
```