### PR TITLE
Reorganise headers

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dust
 Title: Iterate Multiple Realisations of Stochastic Models
-Version: 0.9.12
+Version: 0.9.13
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("John", "Lees", role = "aut"),

--- a/inst/cuda/dust.cu
+++ b/inst/cuda/dust.cu
@@ -1,6 +1,6 @@
 // -*- c++ -*-
 #include <cpp11.hpp>
-#include <dust/device_info.hpp>
+#include <dust/cuda/device_info.hpp>
 
 cpp11::sexp dust_device_info() {
   return dust::cuda::device_info<float>();

--- a/inst/include/dust/cuda/call.hpp
+++ b/inst/include/dust/cuda/call.hpp
@@ -1,6 +1,5 @@
-// -*- c++ -*-
-#ifndef DUST_CUDA_CALL_CUH
-#define DUST_CUDA_CALL_CUH
+#ifndef DUST_CUDA_CALL_HPP
+#define DUST_CUDA_CALL_HPP
 
 #ifdef __NVCC__
 

--- a/inst/include/dust/cuda/containers.hpp
+++ b/inst/include/dust/cuda/containers.hpp
@@ -1,5 +1,5 @@
-#ifndef DUST_CONTAINERS_HPP
-#define DUST_CONTAINERS_HPP
+#ifndef DUST_CUDA_CONTAINERS_HPP
+#define DUST_CUDA_CONTAINERS_HPP
 
 #include <cstdint>
 #include <cstddef>
@@ -9,7 +9,7 @@
 #include <sstream>
 #include <vector>
 
-#include <dust/cuda.cuh>
+#include <dust/cuda/cuda.hpp>
 
 namespace dust {
 

--- a/inst/include/dust/cuda/cuda.hpp
+++ b/inst/include/dust/cuda/cuda.hpp
@@ -1,6 +1,5 @@
-// -*- c++ -*-
-#ifndef DUST_CUDA_CUH
-#define DUST_CUDA_CUH
+#ifndef DUST_CUDA_CUDA_HPP
+#define DUST_CUDA_CUDA_HPP
 
 #ifdef __NVCC__
 #define DEVICE __device__
@@ -19,7 +18,7 @@
 // going to use. This suppresses the warning as it is ok here.
 #define __nv_exec_check_disable__ _Pragma("nv_exec_check_disable")
 
-#include <dust/cuda_call.cuh>
+#include <dust/cuda/call.hpp>
 
 #include <device_launch_parameters.h>
 

--- a/inst/include/dust/cuda/device_info.hpp
+++ b/inst/include/dust/cuda/device_info.hpp
@@ -1,5 +1,5 @@
-#ifndef DUST_DEVICE_INFO_HPP
-#define DUST_DEVICE_INFO_HPP
+#ifndef DUST_CUDA_DEVICE_INFO_HPP
+#define DUST_CUDA_DEVICE_INFO_HPP
 
 #include <vector>
 #include <climits>
@@ -9,7 +9,7 @@
 #include <cpp11/logicals.hpp>
 #include <cpp11/list.hpp>
 #include <cpp11/data_frame.hpp>
-#include <dust/cuda_call.cuh>
+#include <dust/cuda/call.hpp>
 
 namespace dust {
 namespace cuda {

--- a/inst/include/dust/cuda/device_resample.hpp
+++ b/inst/include/dust/cuda/device_resample.hpp
@@ -1,7 +1,7 @@
-#ifndef DUST_DEVICE_RESAMPLE_HPP
-#define DUST_DEVICE_RESAMPLE_HPP
+#ifndef DUST_CUDA_DEVICE_RESAMPLE_HPP
+#define DUST_CUDA_DEVICE_RESAMPLE_HPP
 
-#include <dust/cuda_launch_control.hpp>
+#include <dust/cuda/launch_control.hpp>
 
 namespace dust {
 

--- a/inst/include/dust/cuda/device_state.hpp
+++ b/inst/include/dust/cuda/device_state.hpp
@@ -1,9 +1,8 @@
-// -*- c++ -*-
-#ifndef DUST_DEVICE_STATE_CUH
-#define DUST_DEVICE_STATE_CUH
+#ifndef DUST_CUDA_DEVICE_STATE_CUH
+#define DUST_CUDA_DEVICE_STATE_CUH
 
-#include <dust/cuda.cuh>
-#include <dust/types.hpp>
+#include <dust/cuda/cuda.hpp>
+#include <dust/cuda/types.hpp>
 
 namespace dust {
 

--- a/inst/include/dust/cuda/filter_kernels.hpp
+++ b/inst/include/dust/cuda/filter_kernels.hpp
@@ -1,8 +1,8 @@
-#ifndef DUST_FILTER_KERNELS_HPP
-#define DUST_FILTER_KERNELS_HPP
+#ifndef DUST_CUDA_FILTER_KERNELS_HPP
+#define DUST_CUDA_FILTER_KERNELS_HPP
 
 #include <cmath>
-#include <dust/cuda.cuh>
+#include <dust/cuda/cuda.hpp>
 
 namespace dust {
 

--- a/inst/include/dust/cuda/kernels.hpp
+++ b/inst/include/dust/cuda/kernels.hpp
@@ -1,9 +1,9 @@
-#ifndef DUST_KERNELS_HPP
-#define DUST_KERNELS_HPP
+#ifndef DUST_CUDA_KERNELS_HPP
+#define DUST_CUDA_KERNELS_HPP
 
 #include <assert.h>
 #include <dust/utils.hpp>
-#include <dust/device_state.cuh>
+#include <dust/cuda/device_state.hpp>
 
 namespace dust {
 

--- a/inst/include/dust/cuda/launch_control.hpp
+++ b/inst/include/dust/cuda/launch_control.hpp
@@ -1,7 +1,7 @@
 #ifndef DUST_CUDA_LAUNCH_CONTROL_HPP
 #define DUST_CUDA_LAUNCH_CONTROL_HPP
 
-#include <dust/types.hpp>
+#include <dust/cuda/types.hpp>
 
 namespace dust {
 

--- a/inst/include/dust/cuda/types.hpp
+++ b/inst/include/dust/cuda/types.hpp
@@ -1,11 +1,11 @@
-#ifndef DUST_TYPES_HPP
-#define DUST_TYPES_HPP
+#ifndef DUST_CUDA_TYPES_HPP
+#define DUST_CUDA_TYPES_HPP
 
 #include <numeric>
 #include <sstream>
 #include <vector>
 
-#include <dust/filter_kernels.hpp>
+#include <dust/cuda/filter_kernels.hpp>
 
 namespace dust {
 

--- a/inst/include/dust/densities.hpp
+++ b/inst/include/dust/densities.hpp
@@ -4,7 +4,7 @@
 #include <cmath>
 #include <limits>
 #include <type_traits>
-#include <dust/cuda.cuh>
+#include <dust/cuda/cuda.hpp>
 #include <dust/utils.hpp>
 
 CONSTANT double m_ln_sqrt_2pi_dbl = 0.918938533204672741780329736406;

--- a/inst/include/dust/dust.hpp
+++ b/inst/include/dust/dust.hpp
@@ -15,12 +15,12 @@
 #include <dust/densities.hpp>
 #include <dust/filter_state.hpp>
 #include <dust/filter_tools.hpp>
-#include <dust/types.hpp>
+#include <dust/cuda/types.hpp>
 #include <dust/utils.hpp>
 #include <dust/particle.hpp>
-#include <dust/kernels.hpp>
-#include <dust/device_resample.hpp>
-#include <dust/cuda_launch_control.hpp>
+#include <dust/cuda/kernels.hpp>
+#include <dust/cuda/device_resample.hpp>
+#include <dust/cuda/launch_control.hpp>
 
 namespace dust {
 

--- a/inst/include/dust/interface.hpp
+++ b/inst/include/dust/interface.hpp
@@ -13,9 +13,9 @@
 
 #include <dust/rng_interface.hpp>
 #include <dust/interface_helpers.hpp>
-#include <dust/device_info.hpp>
+#include <dust/cuda/device_info.hpp>
 #include <dust/filter.hpp>
-#include <dust/cuda_launch_control.hpp>
+#include <dust/cuda/launch_control.hpp>
 
 namespace dust {
 

--- a/inst/include/dust/interface_helpers.hpp
+++ b/inst/include/dust/interface_helpers.hpp
@@ -3,8 +3,8 @@
 
 #include <map>
 #include <cpp11/strings.hpp>
-#include <dust/device_info.hpp>
-#include <dust/cuda_launch_control.hpp>
+#include <dust/cuda/device_info.hpp>
+#include <dust/cuda/launch_control.hpp>
 
 namespace dust {
 namespace interface {

--- a/inst/include/dust/rng.hpp
+++ b/inst/include/dust/rng.hpp
@@ -2,13 +2,13 @@
 #define DUST_RNG_HPP
 
 #include <algorithm>
-#include "xoshiro.hpp"
-#include "distr/binomial.hpp"
-#include "distr/exponential.hpp"
-#include "distr/normal.hpp"
-#include "distr/poisson.hpp"
-#include "distr/uniform.hpp"
-#include "containers.hpp"
+#include <dust/xoshiro.hpp>
+#include <dust/distr/binomial.hpp>
+#include <dust/distr/exponential.hpp>
+#include <dust/distr/normal.hpp>
+#include <dust/distr/poisson.hpp>
+#include <dust/distr/uniform.hpp>
+#include <dust/cuda/containers.hpp>
 
 namespace dust {
 

--- a/inst/include/dust/xoshiro.hpp
+++ b/inst/include/dust/xoshiro.hpp
@@ -5,7 +5,7 @@
 #include <vector>
 #include <limits>
 
-#include <dust/cuda.cuh>
+#include <dust/cuda/cuda.hpp>
 
 // This is derived from http://prng.di.unimi.it/xoshiro256starstar.c
 // and http://prng.di.unimi.it/splitmix64.c, copies of which are

--- a/src/test_cuda_launch_control.cpp
+++ b/src/test_cuda_launch_control.cpp
@@ -1,6 +1,6 @@
 #include <cpp11.hpp>
 #include <dust/dust.hpp>
-#include <dust/cuda_launch_control.hpp>
+#include <dust/cuda/launch_control.hpp>
 #include <dust/interface_helpers.hpp>
 
 cpp11::list launch_r_list(const dust::cuda::launch_control& p) {


### PR DESCRIPTION
This PR moves the cuda-related headers to the inst/include/dust/cuda subdir, renames .cuh to .hpp and updates their headerguards (and includes).

Merge after #252, or merge this PR which includes it

Fixes #228 