### PR TITLE
Remove debug print statements

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dust
 Title: Iterate Multiple Realisations of Stochastic Models
-Version: 0.9.14
+Version: 0.9.15
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("John", "Lees", role = "aut"),

--- a/inst/include/dust/cuda/launch_control.hpp
+++ b/inst/include/dust/cuda/launch_control.hpp
@@ -55,7 +55,6 @@ public:
 inline void cuda_profiler_start(const device_config& config) {
 #ifdef DUST_USING_CUDA_PROFILER
   if (config.enabled_) {
-      std::cout << "Starting profiler" << std::endl;
       CUDA_CALL(cudaProfilerStart());
   }
 #endif
@@ -64,7 +63,6 @@ inline void cuda_profiler_start(const device_config& config) {
 inline void cuda_profiler_stop(const device_config& config) {
 #ifdef DUST_USING_CUDA_PROFILER
   if (config.enabled_) {
-      std::cout << "Stopping profiler" << std::endl;
       CUDA_CALL(cudaProfilerStop());
   }
 #endif


### PR DESCRIPTION
Left in by accident, quite annoying in practice!

```
block_size: 64, n_particles: 131072
Starting profiler
Stopping profiler
block_size: 96, n_particles: 131072
Starting profiler
Stopping profiler
block_size: 128, n_particles: 131072
Starting profiler
Stopping profiler
block_size: 160, n_particles: 131072
Starting profiler
Stopping profiler
block_size: 192, n_particles: 131072
Starting profiler
Stopping profiler
block_size: 224, n_particles: 131072
Starting profiler
Stopping profiler
block_size: 256, n_particles: 131072
Starting profiler
Stopping profiler
block_size: 288, n_particles: 131072
Starting profiler
Stopping profiler
block_size: 320, n_particles: 131072
Starting profiler
Stopping profiler
block_size: 352, n_particles: 131072
Starting profiler
Stopping profiler
block_size: 384, n_particles: 131072
Starting profiler
Stopping profiler
block_size: 416, n_particles: 131072
Starting profiler
Stopping profiler
block_size: 448, n_particles: 131072
```