### PR TITLE
Check package name

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dust
 Title: Iterate Multiple Realisations of Stochastic Models
-Version: 0.9.15
+Version: 0.9.16
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("John", "Lees", role = "aut"),

--- a/R/package.R
+++ b/R/package.R
@@ -60,7 +60,8 @@
 ##' dir.create(file.path(dest, "inst/dust"), FALSE, TRUE)
 ##' writeLines(c("Package: example",
 ##'              "Version: 0.0.1",
-##'              "LinkingTo: cpp11, dust"),
+##'              "LinkingTo: cpp11, dust",
+##'              "SystemRequirements: C++11"),
 ##'            file.path(dest, "DESCRIPTION"))
 ##' writeLines("useDynLib('example', .registration = TRUE)",
 ##'            file.path(dest, "NAMESPACE"))

--- a/R/package.R
+++ b/R/package.R
@@ -145,6 +145,7 @@ package_validate <- function(path) {
       "Package name must not contain '.' or '_' (found '%s')", name))
   }
   package_validate_namespace(file.path(path, "NAMESPACE"), name)
+  package_validate_uses_cpp11(path)
 
   path
 }
@@ -226,5 +227,23 @@ package_validate_makevars_openmp <- function(text) {
     grepl("SHLIB_OPENMP_CXXFLAGS", text)
   if (!ok) {
     stop("Package has a 'src/Makevars' but no openmp flags support")
+  }
+}
+
+
+package_validate_uses_cpp11 <- function(path) {
+  desc <- pkgload::pkg_desc(file.path(path, "DESCRIPTION"))
+  makevars <- file.path(path, "src", "Makevars")
+
+  has_cpp11_desc <- desc$has_fields("SystemRequirements") &&
+    grepl("\\bC\\+\\+[0-9][0-9a-z]\\b", desc$get_field("SystemRequirements"),
+          ignore.case = TRUE)
+  has_cpp11_makevars <-
+    file.exists(makevars) && any(grepl("^CXX_STD\\b", readLines(makevars)))
+
+  has_cpp11 <- has_cpp11_desc || has_cpp11_makevars
+
+  if (!has_cpp11) {
+    stop("Did not find a SystemRequirements: C++11 (or similar) in DESCRIPTION")
   }
 }

--- a/R/package.R
+++ b/R/package.R
@@ -140,6 +140,10 @@ package_validate <- function(path) {
   package_validate_has_dep(deps, "dust", "LinkingTo")
 
   name <- desc$get_field("Package")
+  if (grepl("[._]+", name)) {
+    stop(sprintf(
+      "Package name must not contain '.' or '_' (found '%s')", name))
+  }
   package_validate_namespace(file.path(path, "NAMESPACE"), name)
 
   path

--- a/man/dust_package.Rd
+++ b/man/dust_package.Rd
@@ -59,7 +59,8 @@ dir.create(dest)
 dir.create(file.path(dest, "inst/dust"), FALSE, TRUE)
 writeLines(c("Package: example",
              "Version: 0.0.1",
-             "LinkingTo: cpp11, dust"),
+             "LinkingTo: cpp11, dust",
+             "SystemRequirements: C++11"),
            file.path(dest, "DESCRIPTION"))
 writeLines("useDynLib('example', .registration = TRUE)",
            file.path(dest, "NAMESPACE"))

--- a/tests/testthat/examples/pkg/DESCRIPTION
+++ b/tests/testthat/examples/pkg/DESCRIPTION
@@ -7,3 +7,4 @@ Title: An Example Using Dust
 Description: Provides an example of dust within a packge. Not intended to
     be used for anything really.
 License: CC0
+SystemRequirements: C++11

--- a/tests/testthat/test-package.R
+++ b/tests/testthat/test-package.R
@@ -175,3 +175,23 @@ test_that("Validate openmp support in real package", {
     dust_package(path),
     "Package has a 'src/Makevars' but no openmp flags support")
 })
+
+
+test_that("guide user to sensible package name", {
+  path <- create_test_package()
+
+  path_descr <- file.path(path, "DESCRIPTION")
+  descr <- sub("Package: pkg", "Package: my.pkg", readLines(path_descr),
+               fixed = TRUE)
+  writeLines(descr, path_descr)
+
+  path_namespace <- file.path(path, "NAMESPACE")
+  namespace <- sub("pkg", "my.pkg", readLines(path_namespace),
+               fixed = TRUE)
+  writeLines(namespace, path_namespace)
+
+  expect_error(
+    dust_package(path),
+    "Package name must not contain '.' or '_' (found 'my.pkg')",
+    fixed = TRUE)
+})

--- a/tests/testthat/test-package.R
+++ b/tests/testthat/test-package.R
@@ -195,3 +195,28 @@ test_that("guide user to sensible package name", {
     "Package name must not contain '.' or '_' (found 'my.pkg')",
     fixed = TRUE)
 })
+
+
+test_that("check that package uses C++11", {
+  path <- create_test_package()
+
+  expect_silent(
+    package_validate_uses_cpp11(path))
+
+  path_descr <- file.path(path, "DESCRIPTION")
+  descr <- grep("^SystemRequirements:", readLines(path_descr),
+                value = TRUE, invert = TRUE)
+  writeLines(descr, path_descr)
+
+  expect_error(
+    package_validate_uses_cpp11(path),
+    "Did not find a SystemRequirements: C++11 (or similar) in DESCRIPTION",
+    fixed = TRUE)
+
+  writeLines(
+    c("# some makevars file", "CXX_STD = C++11"),
+    file.path(path, "src", "Makevars"))
+
+  expect_silent(
+    package_validate_uses_cpp11(path))
+})

--- a/vignettes/dust.Rmd
+++ b/vignettes/dust.Rmd
@@ -407,6 +407,7 @@ desc <- c(
   "LinkingTo: cpp11, dust",
   "Authors@R: c(person('A', 'Person', role = c('aut', 'cre')",
   "                     email = 'person@example.com'))",
+  "SystemRequirements: C++11",
   "License: CC0")
 ns <- "useDynLib('example', .registration = TRUE)"
 


### PR DESCRIPTION
This PR checks, when using `dust_package` that:

* the package name is valid for both R and C (fixes #259)
* the package declares it needs C++11 (fixes #260, seen only with old compilers)