### PR TITLE
Port to testthat3

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -61,6 +61,7 @@ jobs:
           do
             eval sudo $cmd
           done < <(Rscript -e 'cat(remotes::system_requirements("ubuntu", "20.04"), sep = "\n")')
+          sudo apt install libcurl4-openssl-dev
 
       - name: Install dependencies
         run: |

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dust
 Title: Iterate Multiple Realisations of Stochastic Models
-Version: 0.9.18
+Version: 0.9.19
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("John", "Lees", role = "aut"),
@@ -40,7 +40,8 @@ Suggests:
     knitr,
     mockery,
     rmarkdown,
-    testthat
+    testthat (>= 3.0.0)
 RoxygenNote: 7.1.2
 Roxygen: list(markdown = TRUE)
 VignetteBuilder: knitr
+Config/testthat/edition: 3

--- a/R/compile.R
+++ b/R/compile.R
@@ -78,6 +78,8 @@ compile_and_load <- function(filename, quiet = FALSE, workdir = NULL,
     res$gen <- res$env[[res$data$name]]
 
     cache$models$set(res$key, res, skip_cache)
+  } else if (!quiet) {
+    message("Using cached model")
   }
 
   res$gen

--- a/R/cuda.R
+++ b/R/cuda.R
@@ -292,6 +292,9 @@ cuda_install_cub <- function(path, version = "1.9.10", quiet = FALSE) {
   base <- sprintf("cub-%s", version)
   stopifnot(file.exists(file.path(tmp_src, base)))
 
+  ## We currently print this message regardless of the value of
+  ## 'quiet', which mostly is there to be passed to download.file,
+  ## which otherwise prints all sorts of stuff to stdout.
   message(sprintf("Installing cub headers into %s", path))
   dir.create(path, FALSE, TRUE)
   file.copy(file.path(tmp_src, base, "LICENSE.TXT"), path)

--- a/tests/testthat/helper-dust.R
+++ b/tests/testthat/helper-dust.R
@@ -1,6 +1,5 @@
 skip_for_compilation <- function() {
   testthat::skip_on_cran()
-  testthat::skip("Not opted in to compilation")
 }
 
 

--- a/tests/testthat/helper-dust.R
+++ b/tests/testthat/helper-dust.R
@@ -1,3 +1,9 @@
+skip_for_compilation <- function() {
+  testthat::skip_on_cran()
+  testthat::skip("Not opted in to compilation")
+}
+
+
 r6_private <- function(x) {
   environment(x$initialize)$private
 }

--- a/tests/testthat/test-data.R
+++ b/tests/testthat/test-data.R
@@ -1,9 +1,7 @@
-context("data")
-
 test_that("Can construct dust_data", {
   d <- data.frame(step = seq(0, 50, by = 10), a = runif(6), b = runif(6))
   res <- dust_data(d)
-  expect_is(res, "list")
+  expect_type(res, "list")
   expect_null(names(res))
   expect_length(res, 6)
   expect_equal(lengths(res), rep(2, 6))
@@ -47,7 +45,7 @@ test_that("multiple data, shared", {
   d <- data.frame(step = seq(0, 50, by = 10), a = runif(6), b = runif(6))
   res <- dust_data(d, multi = 3L)
 
-  expect_is(res, "list")
+  expect_type(res, "list")
   expect_null(names(res))
   expect_length(res, 6)
   expect_equal(lengths(res), rep(4, 6))
@@ -62,7 +60,7 @@ test_that("multiple data, different", {
                   a = runif(18), b = runif(18))
 
   res <- dust_data(d, multi = "group")
-  expect_is(res, "list")
+  expect_type(res, "list")
   expect_length(res, 6)
   expect_equal(lengths(res), rep(4, 6))
   expect_identical(lapply(res, "[[", 1), list(0L, 10L, 20L, 30L, 40L, 50L))

--- a/tests/testthat/test-densities.R
+++ b/tests/testthat/test-densities.R
@@ -1,5 +1,3 @@
-context("densities")
-
 ## This one is the easiest:
 test_that("dpois agrees", {
   lambda <- rexp(50)

--- a/tests/testthat/test-example.R
+++ b/tests/testthat/test-example.R
@@ -243,6 +243,7 @@ test_that("validate reorder vector is in correct range", {
 
 
 test_that("run in float mode", {
+  skip_for_compilation()
   res_d <- dust_example("walk")
   res_f <- dust(dust_file("examples/walk.cpp"), real_t = "float", quiet = TRUE)
 
@@ -275,6 +276,7 @@ test_that("reset changes info", {
 
 
 test_that("Basic threading test", {
+  skip_for_compilation()
   res <- dust(dust_file("examples/parallel.cpp"), quiet = TRUE)
 
   obj <- res$new(list(sd = 1), 0, 10, n_threads = 2L, seed = 1L)

--- a/tests/testthat/test-example.R
+++ b/tests/testthat/test-example.R
@@ -1,5 +1,3 @@
-context("example")
-
 test_that("create walk, stepping for one step", {
   res <- dust_example("walk")
   obj <- res$new(list(sd = 1), 0, 10, seed = 1L)
@@ -323,13 +321,9 @@ test_that("Basic threading test", {
 test_that("cache hits do not compile", {
   skip_on_cran()
   cmp <- dust(dust_file("examples/walk.cpp"), quiet = TRUE)
-
-  mock <- mockery::mock()
-  res <- with_mock(
-    "pkgbuild::compile_dll" = mock,
-    dust(dust_file("examples/walk.cpp"), quiet = TRUE))
-  ## Never called
-  expect_equal(mockery::mock_calls(mock), list())
+  expect_message(
+    res <- dust(dust_file("examples/walk.cpp"), quiet = FALSE),
+    "Using cached model")
   ## Same object
   expect_identical(res, cmp)
 })

--- a/tests/testthat/test-filter.R
+++ b/tests/testthat/test-filter.R
@@ -1,5 +1,3 @@
-context("filter")
-
 test_that("Can run the filter", {
   dat <- example_filter()
 

--- a/tests/testthat/test-interface.R
+++ b/tests/testthat/test-interface.R
@@ -1,4 +1,5 @@
 test_that("Basic interface use", {
+  skip_for_compilation()
   filename <- dust_file("examples/walk.cpp")
   res <- dust(filename, quiet = TRUE)
   expect_s3_class(res, "dust_generator")
@@ -91,6 +92,7 @@ test_that("dust_workdir will error if path is not a directory", {
 
 
 test_that("validate interface", {
+  skip_for_compilation()
   res <- dust(dust_file("examples/walk.cpp"), quiet = TRUE)
   cmp <- dust_generator
 
@@ -174,6 +176,7 @@ test_that("set rng state", {
 
 
 test_that("setting a named index returns names", {
+  skip_for_compilation()
   res <- dust(dust_file("examples/sirs.cpp"), quiet = TRUE)
   mod <- res$new(list(), 0, 10)
 
@@ -290,6 +293,7 @@ test_that("step must be nonnegative", {
 
 
 test_that("Can get parameters from generators", {
+  skip_for_compilation()
   res <- dust(dust_file("examples/sirs.cpp"), quiet = TRUE)
   expect_s3_class(res, "dust_generator")
   expect_equal(coef(res), parse_metadata(dust_file("examples/sirs.cpp"))$param)

--- a/tests/testthat/test-interface.R
+++ b/tests/testthat/test-interface.R
@@ -1,11 +1,9 @@
-context("interface")
-
 test_that("Basic interface use", {
   filename <- dust_file("examples/walk.cpp")
   res <- dust(filename, quiet = TRUE)
-  expect_is(res, "dust_generator")
+  expect_s3_class(res, "dust_generator")
   obj <- res$new(list(sd = 1), 0L, 100L)
-  expect_is(obj, "dust")
+  expect_s3_class(obj, "dust")
 })
 
 
@@ -14,9 +12,9 @@ test_that("Interface passes arguments as expected", {
   filename <- dust_file("examples/walk.cpp")
   mock_compile_and_load <- mockery::mock(NULL)
   workdir <- tempfile()
-  with_mock(
-    "dust::compile_and_load" = mock_compile_and_load,
-    dust(filename, TRUE, workdir))
+
+  mockery::stub(dust, "compile_and_load", mock_compile_and_load)
+  dust(filename, TRUE, workdir)
 
   mockery::expect_called(mock_compile_and_load, 1L)
   expect_equal(
@@ -364,9 +362,9 @@ test_that("create temporary package", {
     read.dcf(file.path(path, "DESCRIPTION"))[, "Package"],
     "^walk[[:xdigit:]]{8}$")
   pkg <- pkgload::load_all(path, quiet = TRUE, export_all = FALSE)
-  expect_is(pkg$env$walk, "dust_generator")
+  expect_s3_class(pkg$env$walk, "dust_generator")
   obj <- pkg$env$walk$new(list(sd = 1), 0L, 100L)
-  expect_is(obj, "dust")
+  expect_s3_class(obj, "dust")
 })
 
 

--- a/tests/testthat/test-metadata.R
+++ b/tests/testthat/test-metadata.R
@@ -1,5 +1,3 @@
-context("metadata")
-
 test_that("parse sir model metadata", {
   meta <- parse_metadata(dust_file("examples/sir.cpp"))
   expect_equal(meta$class, "sir")

--- a/tests/testthat/test-multi.R
+++ b/tests/testthat/test-multi.R
@@ -1,5 +1,3 @@
-context("multi")
-
 test_that("create trivial multi dust object", {
   res <- dust_example("walk")
   obj1 <- res$new(list(sd = 1), 0, 10, seed = 1L, pars_multi = FALSE)

--- a/tests/testthat/test-package.R
+++ b/tests/testthat/test-package.R
@@ -1,5 +1,3 @@
-context("package")
-
 test_that("validate package", {
   skip_if_not_installed("pkgload")
   skip_on_cran()
@@ -9,7 +7,7 @@ test_that("validate package", {
   file.remove(file.path(path, "R"))
   file.remove(file.path(path, "src"))
 
-  path <- dust_package(path)
+  path <- dust_package(path, quiet = TRUE)
   expect_false(any(grepl("##'", readLines(file.path(path, "R", "dust.R")))))
 
   expect_true(file.exists(file.path(path, "src/Makevars")))
@@ -18,7 +16,7 @@ test_that("validate package", {
     readLines(dust_file("template/Makevars.pkg")))
 
   pkgbuild::compile_dll(path, quiet = TRUE)
-  res <- pkgload::load_all(path)
+  res <- pkgload::load_all(path, quiet = TRUE)
   w <- res$env$walk$new(list(sd = 1), 0, 100)
   expect_equal(w$state(), matrix(0, 1, 100))
 

--- a/tests/testthat/test-rng.R
+++ b/tests/testthat/test-rng.R
@@ -1,5 +1,3 @@
-context("rng")
-
 test_that("can generate random numbers", {
   ans1 <- dust_rng$new(1, 1)$unif_rand(100)
   ans2 <- dust_rng$new(1, 1)$unif_rand(100)
@@ -171,8 +169,8 @@ test_that("poisson numbers", {
   expect_identical(ans1, ans2)
   expect_false(all(ans1 == ans3))
 
-  expect_equal(mean(ans1), lambda, 1e-2)
-  expect_equal(var(ans1), lambda, 1e-2)
+  expect_equal(mean(ans1), lambda, tolerance = 1e-2)
+  expect_equal(var(ans1), lambda, tolerance = 1e-2)
 })
 
 
@@ -186,8 +184,8 @@ test_that("Big poisson numbers", {
   expect_identical(ans1, ans2)
   expect_false(all(ans1 == ans3))
 
-  expect_equal(mean(ans1), lambda, 1e-2)
-  expect_equal(var(ans1), lambda, 1e-2)
+  expect_equal(mean(ans1), lambda, tolerance = 1e-2)
+  expect_equal(var(ans1), lambda, tolerance = 1e-2)
 })
 
 

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -1,5 +1,3 @@
-context("utils")
-
 test_that("null-or-value works", {
   expect_equal(1 %||% NULL, 1)
   expect_equal(1 %||% 2, 1)


### PR DESCRIPTION
This PR ports the package to use testthat 3e, and skips compilation-requiring tests on CRAN

~Merge after #267~

Fixes #266 
Fixes #265