### PR TITLE
Support both versions of dnbinom

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dust
 Title: Iterate Multiple Realisations of Stochastic Models
-Version: 0.9.19
+Version: 0.9.20
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("John", "Lees", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# dust 0.9.20
+
+* Change to the `dust::densities::dnbinom()` to offer both of the same
+parameterisations as R's `dnbinom`, explicitly as `dust::densities::dnbinom_mu()` and `dust::densities::dnbinom_prob()` (#171)
+
 # dust 0.9.18
 
 * New function `dust::dust_generate` for creating a mini-package from a dust model for inspection or later loading (#204)

--- a/R/cpp11.R
+++ b/R/cpp11.R
@@ -8,8 +8,12 @@ dust_dnorm <- function(x, mu, sd, log) {
   .Call(`_dust_dust_dnorm`, x, mu, sd, log)
 }
 
-dust_dnbinom <- function(x, size, mu, log, is_float) {
-  .Call(`_dust_dust_dnbinom`, x, size, mu, log, is_float)
+dust_dnbinom_mu <- function(x, size, mu, log, is_float) {
+  .Call(`_dust_dust_dnbinom_mu`, x, size, mu, log, is_float)
+}
+
+dust_dnbinom_prob <- function(x, size, prob, log) {
+  .Call(`_dust_dust_dnbinom_prob`, x, size, prob, log)
 }
 
 dust_dbetabinom <- function(x, size, prob, rho, log) {

--- a/inst/include/dust/densities.hpp
+++ b/inst/include/dust/densities.hpp
@@ -85,7 +85,7 @@ HOSTDEVICE T dnorm(T x, T mu, T sd, bool log) {
 }
 
 template <typename T>
-HOSTDEVICE T dnbinom(int x, T size, T mu, bool log) {
+HOSTDEVICE T dnbinom_mu(int x, T size, T mu, bool log) {
 #ifndef __CUDA_ARCH__
   static_assert(std::is_floating_point<T>::value,
                 "dnbinom should only be used with real types");
@@ -119,6 +119,14 @@ HOSTDEVICE T dnbinom(int x, T size, T mu, bool log) {
 
   SYNCWARP
   return maybe_log(ret, log);
+}
+
+// This may not be stable for all size and prob, but provides
+// compatibility with R's C-level function. See ?dnbinom for details.
+template <typename T>
+HOSTDEVICE T dnbinom_prob(int x, T size, T prob, bool log) {
+  const T mu = size * (1 - prob) / prob;
+  return dnbinom_mu(x, size, mu, log);
 }
 
 // A note on this parametrisation:

--- a/src/cpp11.cpp
+++ b/src/cpp11.cpp
@@ -20,10 +20,17 @@ extern "C" SEXP _dust_dust_dnorm(SEXP x, SEXP mu, SEXP sd, SEXP log) {
   END_CPP11
 }
 // densities.cpp
-SEXP dust_dnbinom(cpp11::integers x, cpp11::doubles size, cpp11::doubles mu, bool log, bool is_float);
-extern "C" SEXP _dust_dust_dnbinom(SEXP x, SEXP size, SEXP mu, SEXP log, SEXP is_float) {
+SEXP dust_dnbinom_mu(cpp11::integers x, cpp11::doubles size, cpp11::doubles mu, bool log, bool is_float);
+extern "C" SEXP _dust_dust_dnbinom_mu(SEXP x, SEXP size, SEXP mu, SEXP log, SEXP is_float) {
   BEGIN_CPP11
-    return cpp11::as_sexp(dust_dnbinom(cpp11::as_cpp<cpp11::decay_t<cpp11::integers>>(x), cpp11::as_cpp<cpp11::decay_t<cpp11::doubles>>(size), cpp11::as_cpp<cpp11::decay_t<cpp11::doubles>>(mu), cpp11::as_cpp<cpp11::decay_t<bool>>(log), cpp11::as_cpp<cpp11::decay_t<bool>>(is_float)));
+    return cpp11::as_sexp(dust_dnbinom_mu(cpp11::as_cpp<cpp11::decay_t<cpp11::integers>>(x), cpp11::as_cpp<cpp11::decay_t<cpp11::doubles>>(size), cpp11::as_cpp<cpp11::decay_t<cpp11::doubles>>(mu), cpp11::as_cpp<cpp11::decay_t<bool>>(log), cpp11::as_cpp<cpp11::decay_t<bool>>(is_float)));
+  END_CPP11
+}
+// densities.cpp
+SEXP dust_dnbinom_prob(cpp11::integers x, cpp11::doubles size, cpp11::doubles prob, bool log);
+extern "C" SEXP _dust_dust_dnbinom_prob(SEXP x, SEXP size, SEXP prob, SEXP log) {
+  BEGIN_CPP11
+    return cpp11::as_sexp(dust_dnbinom_prob(cpp11::as_cpp<cpp11::decay_t<cpp11::integers>>(x), cpp11::as_cpp<cpp11::decay_t<cpp11::doubles>>(size), cpp11::as_cpp<cpp11::decay_t<cpp11::doubles>>(prob), cpp11::as_cpp<cpp11::decay_t<bool>>(log)));
   END_CPP11
 }
 // densities.cpp
@@ -864,7 +871,8 @@ static const R_CallMethodDef CallEntries[] = {
     {"_dust_cpp_scale_log_weights",         (DL_FUNC) &_dust_cpp_scale_log_weights,         1},
     {"_dust_dust_dbetabinom",               (DL_FUNC) &_dust_dust_dbetabinom,               5},
     {"_dust_dust_dbinom",                   (DL_FUNC) &_dust_dust_dbinom,                   4},
-    {"_dust_dust_dnbinom",                  (DL_FUNC) &_dust_dust_dnbinom,                  5},
+    {"_dust_dust_dnbinom_mu",               (DL_FUNC) &_dust_dust_dnbinom_mu,               5},
+    {"_dust_dust_dnbinom_prob",             (DL_FUNC) &_dust_dust_dnbinom_prob,             4},
     {"_dust_dust_dnorm",                    (DL_FUNC) &_dust_dust_dnorm,                    4},
     {"_dust_dust_dpois",                    (DL_FUNC) &_dust_dust_dpois,                    3},
     {"_dust_dust_rng_alloc",                (DL_FUNC) &_dust_dust_rng_alloc,                3},

--- a/src/densities.cpp
+++ b/src/densities.cpp
@@ -25,23 +25,33 @@ SEXP dust_dnorm(cpp11::doubles x, cpp11::doubles mu, cpp11::doubles sd,
 }
 
 template <typename T>
-SEXP dust_dnbinom_(cpp11::integers x, cpp11::doubles size, cpp11::doubles mu,
-                   bool log) {
+SEXP dust_dnbinom_mu_(cpp11::integers x, cpp11::doubles size, cpp11::doubles mu,
+                      bool log) {
   const size_t n = x.size();
   cpp11::writable::doubles ret(x.size());
   for (size_t i = 0; i < n; ++i) {
-    ret[i] = dust::dnbinom<T>(x[i], size[i], mu[i], log);
+    ret[i] = dust::dnbinom_mu<T>(x[i], size[i], mu[i], log);
   }
   return ret;
 }
 
+[[cpp11::register]]
+SEXP dust_dnbinom_mu(cpp11::integers x, cpp11::doubles size, cpp11::doubles mu,
+                     bool log, bool is_float) {
+  return is_float ?
+    dust_dnbinom_mu_<float>(x, size, mu, log) :
+    dust_dnbinom_mu_<double>(x, size, mu, log);
+}
 
 [[cpp11::register]]
-SEXP dust_dnbinom(cpp11::integers x, cpp11::doubles size, cpp11::doubles mu,
-                  bool log, bool is_float) {
-  return is_float ?
-    dust_dnbinom_<float>(x, size, mu, log) :
-    dust_dnbinom_<double>(x, size, mu, log);
+SEXP dust_dnbinom_prob(cpp11::integers x, cpp11::doubles size,
+                       cpp11::doubles prob, bool log) {
+  const size_t n = x.size();
+  cpp11::writable::doubles ret(x.size());
+  for (size_t i = 0; i < n; ++i) {
+    ret[i] = dust::dnbinom_prob<double>(x[i], size[i], prob[i], log);
+  }
+  return ret;
 }
 
 [[cpp11::register]]

--- a/tests/testthat/test-densities.R
+++ b/tests/testthat/test-densities.R
@@ -61,72 +61,89 @@ test_that("dnbinom agrees", {
     prob <- runif(length(size))
     mu <- size * (1 - prob) / prob
     x <- as.integer(sample(size, replace = TRUE))
-    expect_equal(dust_dnbinom(x, size, mu, TRUE, is_float),
+    expect_equal(dust_dnbinom_mu(x, size, mu, TRUE, is_float),
                  dnbinom(x, size, mu = mu, log = TRUE),
                  tolerance = tolerance)
-    expect_equal(dust_dnbinom(x, size, mu, FALSE, is_float),
+    expect_equal(dust_dnbinom_mu(x, size, mu, FALSE, is_float),
                  dnbinom(x, size, mu = mu, log = FALSE),
                  tolerance = tolerance)
 
     ## size > x case which was implemented incorrectly in <= v0.6.5
     expect_equal(
       dnbinom(511, 2, mu = 6.65, log = TRUE),
-      dust_dnbinom(511L, 2, 6.65, TRUE, is_float),
+      dust_dnbinom_mu(511L, 2, 6.65, TRUE, is_float),
       tolerance = tolerance)
 
     ## Allow non integer size (wrong in <= 0.7.5)
     expect_equal(
-      dust_dnbinom(511L, 3.5, 1, TRUE, is_float),
+      dust_dnbinom_mu(511L, 3.5, 1, TRUE, is_float),
       dnbinom(511, 3.5, mu = 1, log = TRUE),
       tolerance = tolerance)
 
     ## Corner cases
-    expect_equal(dust_dnbinom(0L, 0, 0, TRUE, is_float),
+    expect_equal(dust_dnbinom_mu(0L, 0, 0, TRUE, is_float),
                  dnbinom(0, 0, mu = 0, log = TRUE))
-    expect_equal(dust_dnbinom(0L, 0, 0, FALSE, is_float),
+    expect_equal(dust_dnbinom_mu(0L, 0, 0, FALSE, is_float),
                  dnbinom(0, 0, mu = 0, log = FALSE))
-    expect_equal(dust_dnbinom(0L, 0, 0.5, FALSE, is_float),
+    expect_equal(dust_dnbinom_mu(0L, 0, 0.5, FALSE, is_float),
                  dnbinom(0, 0, mu = 0.5, log = FALSE))
-    expect_equal(dust_dnbinom(10L, 0, 1, TRUE, is_float),
+    expect_equal(dust_dnbinom_mu(10L, 0, 1, TRUE, is_float),
                  suppressWarnings(dnbinom(10L, 0L, mu = 1, log = TRUE)))
-    expect_equal(dust_dnbinom(10L, 1, 1, TRUE, is_float),
+    expect_equal(dust_dnbinom_mu(10L, 1, 1, TRUE, is_float),
                  dnbinom(10L, 1L, mu = 1, log = TRUE))
-    expect_equal(dust_dnbinom(10L, 0, 1, FALSE, is_float),
+    expect_equal(dust_dnbinom_mu(10L, 0, 1, FALSE, is_float),
                  suppressWarnings(dnbinom(10L, 0L, mu = 1, log = FALSE)))
-    expect_equal(dust_dnbinom(0L, 10, 1, TRUE, is_float),
+    expect_equal(dust_dnbinom_mu(0L, 10, 1, TRUE, is_float),
                  suppressWarnings(dnbinom(0L, 10L, mu = 1, log = TRUE)),
                  tolerance = tolerance)
     ## We disagree with R here; we *could* return NaN but -Inf seems
     ## more sensible, and is what R returns if mu = eps
-    expect_equal(dust_dnbinom(10L, 0, 0, TRUE, is_float), -Inf)
+    expect_equal(dust_dnbinom_mu(10L, 0, 0, TRUE, is_float), -Inf)
 
     expect_equal(
-      dust_dnbinom(x = 0L, size = 2, mu = 0, log = TRUE, is_float = is_float),
+      dust_dnbinom_mu(x = 0L, size = 2, mu = 0, log = TRUE,
+                      is_float = is_float),
       dnbinom(x = 0, size = 2, mu = 0, log = TRUE))
     expect_equal(
-      dust_dnbinom(x = 0L, size = 2, mu = 0, log = FALSE, is_float = is_float),
+      dust_dnbinom_mu(x = 0L, size = 2, mu = 0, log = FALSE,
+                      is_float = is_float),
       dnbinom(x = 0, size = 2, mu = 0, log = FALSE))
     expect_equal(
-      dust_dnbinom(x = 1L, size = 2, mu = 0, log = TRUE, is_float = is_float),
+      dust_dnbinom_mu(x = 1L, size = 2, mu = 0, log = TRUE,
+                      is_float = is_float),
       dnbinom(x = 1, size = 2, mu = 0, log = TRUE))
     expect_equal(
-      dust_dnbinom(x = 1L, size = 2, mu = 0, log = FALSE, is_float = is_float),
+      dust_dnbinom_mu(x = 1L, size = 2, mu = 0, log = FALSE,
+                      is_float = is_float),
       dnbinom(x = 1, size = 2, mu = 0, log = FALSE))
 
     ## Special case where mu is zero
     expect_equal(
       dnbinom(34, 2, mu = 0, log = TRUE),
-      dust_dnbinom(34L, 2, 0, TRUE, is_float))
+      dust_dnbinom_mu(34L, 2, 0, TRUE, is_float))
     expect_equal(
       dnbinom(34, 2, mu = 0, log = FALSE),
-      dust_dnbinom(34L, 2, 0, FALSE, is_float))
+      dust_dnbinom_mu(34L, 2, 0, FALSE, is_float))
 
     ## Special case of mu << size
-    expect_equal(dust_dnbinom(0L, 50, 1e-8, TRUE, is_float),
+    expect_equal(dust_dnbinom_mu(0L, 50, 1e-8, TRUE, is_float),
                  dnbinom(0L, size = 50, mu = 1e-8, log = TRUE))
-    expect_equal(dust_dnbinom(0L, 50, 1e-20, TRUE, is_float),
+    expect_equal(dust_dnbinom_mu(0L, 50, 1e-20, TRUE, is_float),
                  dnbinom(0L, size = 50, mu = 1e-20, log = TRUE))
   }
+})
+
+
+## This is very basic for now, we can expand it to pick up the corner
+## cases when it is more widely used.
+test_that("dnbinom agrees in prob mode", {
+  x <- 0:11
+  size <- rep(1, length(x))
+  prob <- rep(0.5, length(x))
+  expect_equal(dust_dnbinom_prob(x, size, prob, TRUE),
+               dnbinom(x, size, prob, log = TRUE))
+  expect_equal(dust_dnbinom_prob(x, size, prob, FALSE),
+               dnbinom(x, size, prob, log = FALSE))
 })
 
 


### PR DESCRIPTION
This improves the API and makes it much more obvious how the distributions are represented.

I have a branch with a small patch for sircovid moving from using `dust::densities::dnbinom` to `dust::densities::dnbinom_mu` - not pushed up yet to avoid some boring cache issues that we get on CI with rapid cross-repo merges

Fixes #171 