### PR TITLE
better pkgdown

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -26,3 +26,4 @@
 ^extra$
 ^inst/random/openmp/rnguse$
 ^inst/random/openmp/Makefile$
+^_pkgdown\.yml$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dust
 Title: Iterate Multiple Realisations of Stochastic Models
-Version: 0.11.12
+Version: 0.11.13
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("John", "Lees", role = "aut"),

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ There are further vignettes describing details:
 
 * `vignette("rng")` on the parallel random number generator used
 * `vignette("rng_algorithms")` on the details of algorithms used to sample from some distributions
-* `vigette("rng_package")` on using the generators from other packages
+* `vignette("rng_package")` on using the generators from other packages
 
 You can also read our open access paper describing `dust` and some related tools that use it:
 

--- a/README.md
+++ b/README.md
@@ -26,9 +26,12 @@ Two vignettes provide an overview of the package, depending on your tastes:
 There are further vignettes describing details:
 
 * `vignette("multi")` on simulating multiple parameter sets at once
-* `vignette("rng")` on the parallel random number generator used
 * `vignette("data")` on running a bootstrap particle filter
-* `vignette("cuda")` on creating and running models on GPUs
+* `vignette("gpu")` on creating and running models on GPUs
+
+* `vignette("rng")` on the parallel random number generator used
+* `vignette("rng_algorithms")` on the details of algorithms used to sample from some distributions
+* `vigette("rng_package")` on using the generators from other packages
 
 You can also read our open access paper describing `dust` and some related tools that use it:
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ There are further vignettes describing details:
 * `vignette("data")` on running a bootstrap particle filter
 * `vignette("gpu")` on creating and running models on GPUs
 
+And several on the random number generator, around which dust is built:
+
 * `vignette("rng")` on the parallel random number generator used
 * `vignette("rng_algorithms")` on the details of algorithms used to sample from some distributions
 * `vignette("rng_package")` on using the generators from other packages

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -13,7 +13,7 @@ reference:
       Every dust model shares the same (fairly large) set of methods
     contents:
       - dust_generator
-  
+
   - title: Random numbers
     desc: >-
       The core of dust is a parallel random number generator. These

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -53,8 +53,8 @@ articles:
     navbar: Random numbers
     contents:
       - rng
+      - rng_algorithms
       - rng_package
-      - rng_normal
 
   - title: Use cases
     navbar: Dive deeper

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,0 +1,64 @@
+reference:
+  - title: Generate a dust model
+    desc: >-
+      Convert a small section of C++ code into a model that can be run
+      efficiently in parallel.
+    contents:
+      - dust
+      - dust_generate
+      - dust_package
+
+  - title: Interact with the dust model
+    desc: >-
+      Every dust model shares the same (fairly large) set of methods
+    contents:
+      - dust_generator
+  
+  - title: Random numbers
+    desc: >-
+      The core of dust is a parallel random number generator. These
+      are also described in a series of vignettes.
+    contents:
+      - dust_rng
+      - dust_rng_pointer
+      - dust_rng_state_long_jump
+
+  - title: Run in parallel with OpenMP
+    desc: >-
+      Detect OpenMP support
+    contents:
+      - dust_openmp_support
+      - dust_openmp_threads
+
+  - title: Compile on GPUs
+    desc: >-
+      Control compilation options for creating models to run on a GPU
+    contents:
+      - dust_cuda_configuration
+      - dust_cuda_options
+
+  - title: Other
+    contents:
+      - dust_data
+      - dust_example
+
+articles:
+  - title: Introduction
+    navbar: ~
+    contents:
+      - dust
+      - design
+
+  - title: Random numbers
+    navbar: Random numbers
+    contents:
+      - rng
+      - rng_package
+      - rng_normal
+
+  - title: Use cases
+    navbar: Dive deeper
+    contents:
+      - data
+      - gpu
+      - multi

--- a/vignettes/data.Rmd
+++ b/vignettes/data.Rmd
@@ -22,7 +22,7 @@ plain_output <- function(x) lang_output(x, "plain")
 
 One of our aims with `dust` was to enable the creation of fast particle filters. Most of the high level interface for this is within the package [`mcstate`](https://mrc-ide.github.io/mcstate/).  Typically, when using a `dust` model with `mcstate`, you would define a function in R which compares the model state at some point in time to some data, returning a likelihood.
 
-It is possible to implement this comparison directly in the dust model, which may slightly speed up the particle filter (because the compare function will be evaluated in parallel, and because of slightly reduced data copying), but also allows running the particle filter on a GPU (see `vignette("cuda")`).
+It is possible to implement this comparison directly in the dust model, which may slightly speed up the particle filter (because the compare function will be evaluated in parallel, and because of slightly reduced data copying), but also allows running the particle filter on a GPU (see `vignette("gpu")`).
 
 This vignette outlines the steps in implementing the comparison directly as part of the model.  This is not required for basic use of dust models, and we would typically recommend this only after your model has stabilised and you are looking to extract potential additional speed-ups or accelerate the model on a GPU.
 
@@ -192,4 +192,4 @@ points(observed ~ step, data, type = "p", pch = 19, col = "blue")
 
 Typically, you would use the much higher level interface in `mcstate` for this, though.
 
-Some additional work is required if you want to run the comparison on a GPU, see `vignette("cuda")` for more details.
+Some additional work is required if you want to run the comparison on a GPU, see `vignette("gpu")` for more details.

--- a/vignettes/rng_algorithms.Rmd
+++ b/vignettes/rng_algorithms.Rmd
@@ -1,5 +1,5 @@
 ---
-title: "Computing normally distributed random numbers"
+title: "Algorithms used to compute random numbers"
 output: rmarkdown::html_vignette
 vignette: >
   %\VignetteIndexEntry{Computing normally distributed random numbers}

--- a/vignettes/rng_algorithms.Rmd
+++ b/vignettes/rng_algorithms.Rmd
@@ -2,7 +2,7 @@
 title: "Algorithms used to compute random numbers"
 output: rmarkdown::html_vignette
 vignette: >
-  %\VignetteIndexEntry{Computing normally distributed random numbers}
+  %\VignetteIndexEntry{Algorithms used to compute random numbers}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
 ---


### PR DESCRIPTION
This PR adds sections to the generated pkgdown site. We have no preview system set up (we probably should at some point), but `pkgdown::build_site()` locally with this branch shows the effect

* reference split into sections
* the increasingly large number of vignettes split up

This time without @maelle even prompting me