### PR TITLE
Allow underscores in dust::name and similar

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dust
 Title: Iterate Multiple Realisations of Stochastic Models
-Version: 0.11.21
+Version: 0.11.22
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("John", "Lees", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# dust 0.11.22
+
+* Allow model names with underscores (#358, see also [odin.dust#98](https://github.com/mrc-ide/odin.dust/issues/98))
+
 # dust 0.11.21
 
 * Remove the functionality that allowed a vector of start times to be provided, as we were never using it and it simplifes things to remove it (#310)

--- a/R/compile.R
+++ b/R/compile.R
@@ -1,9 +1,12 @@
 generate_dust <- function(filename, quiet, workdir, cuda, skip_cache, mangle) {
   config <- parse_metadata(filename)
-  if (mangle) {
-    base <- sprintf("%s%s", config$name, hash_file(filename))
-  } else {
+  if (grepl("^[A-Za-z][A-Zxa-z0-9]*$", config$name)) {
     base <- config$name
+  } else {
+    base <- "dust"
+  }
+  if (mangle) {
+    base <- paste0(base, hash_file(filename))
   }
   gpu <- isTRUE(cuda$has_cuda)
   if (gpu) {

--- a/R/metadata.R
+++ b/R/metadata.R
@@ -17,8 +17,6 @@ parse_metadata <- function(filename) {
     ret$has_gpu_support <- parse_code_has_gpu_support(readLines(filename))
   }
 
-  assert_valid_name(ret$name)
-
   ret
 }
 
@@ -46,7 +44,12 @@ parse_metadata_simple <- function(data, attribute) {
 
 
 parse_metadata_name <- function(data) {
-  parse_metadata_simple(data, "dust::name")
+  name <- parse_metadata_simple(data, "dust::name")
+  if (!is.null(name) && !grepl("^[A-Za-z][A-Za-z0-9_]*$", name)) {
+    stop(paste("'[[dust::name]]' must contain only letters, numbers and",
+               "underscores, starting with a letter"))
+  }
+  name
 }
 
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -22,15 +22,6 @@ read_lines <- function(path) {
 }
 
 
-assert_valid_name <- function(x, name = deparse(substitute(x))) {
-  if (!grepl("^[A-Za-z][A-Zxa-z0-9]*$", x)) {
-    stop(sprintf(
-      "'%s' must contain only letters and numbers, starting with a letter",
-      name))
-  }
-}
-
-
 assert_file_exists <- function(path, name = "File") {
   if (!file.exists(path)) {
     stop(sprintf("%s '%s' does not exist", name, path))

--- a/tests/testthat/test-interface.R
+++ b/tests/testthat/test-interface.R
@@ -444,4 +444,9 @@ test_that("allow compilation of model with underscore in the name", {
   expect_equal(gen$public_methods$name(), "walk_model")
   expect_match(environmentName(gen$parent_env),
                "^dust[[:xdigit:]]+$")
+
+  ## Validate that the dll actually works too
+  mod <- gen$new(list(sd = 1), 0, 1)
+  expect_s3_class(mod, "dust")
+  expect_equal(mod$name(), "walk_model")
 })

--- a/tests/testthat/test-interface.R
+++ b/tests/testthat/test-interface.R
@@ -432,3 +432,16 @@ test_that("Particles are initialised based on time", {
   mod <- res$new(list(sd = 1), 4, 5)
   expect_equal(mod$state(), matrix(4, 1, 5))
 })
+
+
+test_that("allow compilation of model with underscore in the name", {
+  skip_for_compilation()
+  code <- readLines(dust_file("examples/walk.cpp"))
+  code <- gsub("walk", "walk_model", code, fixed = TRUE)
+  tmp <- tempfile()
+  writeLines(code, tmp)
+  gen <- dust(tmp, quiet = TRUE)
+  expect_equal(gen$public_methods$name(), "walk_model")
+  expect_match(environmentName(gen$parent_env),
+               "^dust[[:xdigit:]]+$")
+})

--- a/tests/testthat/test-metadata.R
+++ b/tests/testthat/test-metadata.R
@@ -209,3 +209,14 @@ test_that("force gpu state", {
     parse_metadata(tmp2),
     "Invalid value for dust::has_gpu_support, expected logical")
 })
+
+
+test_that("Can prevent invalid names", {
+  tmp <- helper_metadata(
+    "// [[dust::name(my.model)]]")
+  on.exit(unlink(tmp))
+  expect_error(
+    parse_metadata(tmp),
+    "'[[dust::name]]' must contain only letters, numbers and underscores",
+    fixed = TRUE)
+})

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -6,17 +6,6 @@ test_that("null-or-value works", {
 })
 
 
-test_that("valid name", {
-  x <- "1name"
-  expect_error(assert_valid_name(x),
-               "'x' must contain only letters and numbers")
-  expect_error(assert_valid_name("foo_bar"),
-               "'.+' must contain only letters and numbers")
-  expect_error(assert_valid_name("foo.bar"),
-               "'.+' must contain only letters and numbers")
-})
-
-
 test_that("assert_file_exists", {
   p <- tempfile()
   expect_error(assert_file_exists(p), "File '.+' does not exist")


### PR DESCRIPTION
See https://github.com/mrc-ide/odin.dust/issues/98 for the trigger.  We just fall back to using `dust` for the dll name which should work fine.  For packages, this is not a problem at all.

Fixes #358 
Fixes https://github.com/mrc-ide/odin.dust/issues/98