### PR TITLE
mrc-3377: fix docs build

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -3,7 +3,7 @@ on:
     branches:
       - master
       - main
-      - mrc-3221
+      - mrc-3377
 
 name: pkgdown
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dust
 Title: Iterate Multiple Realisations of Stochastic Models
-Version: 0.11.28
+Version: 0.11.29
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("John", "Lees", role = "aut"),

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -42,6 +42,7 @@ reference:
     contents:
       - dust_data
       - dust_example
+      - dust_repair_environment
 
 articles:
   - title: Introduction

--- a/scripts/docs_build
+++ b/scripts/docs_build
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -x
+set -ex
 ./scripts/docs_build_cpp
 
 rm -rf docs


### PR DESCRIPTION
I noticed the docs build for dust was broken, while trying to show off the docs!