### PR TITLE
Add metadata parse support

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dust
 Title: Iterate Multiple Realisations of Stochastic Models
-Version: 0.12.1
+Version: 0.12.2
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Alex", "Hill", role = "aut"),

--- a/R/metadata.R
+++ b/R/metadata.R
@@ -3,6 +3,7 @@ parse_metadata <- function(filename) {
   ret <- list(name = parse_metadata_name(data),
               class = parse_metadata_class(data),
               param = parse_metadata_param(data),
+              time_type = parse_metadata_time_type(data),
               has_gpu_support = parse_metadata_has_gpu_support(data))
 
   if (is.null(ret$class)) {
@@ -55,6 +56,19 @@ parse_metadata_name <- function(data) {
 
 parse_metadata_class <- function(data) {
   parse_metadata_simple(data, "dust::class")
+}
+
+
+parse_metadata_time_type <- function(data) {
+  value <- parse_metadata_simple(data, "dust::time_type") %||% "discrete"
+  if (!is.null(value)) {
+    valid <- c("continuous", "discrete")
+    if (!(value %in% valid)) {
+      stop(sprintf("Invalid value for dust::time_type, expected one of %s",
+                   paste(squote(valid), collapse = ", ")))
+    }
+  }
+  value
 }
 
 

--- a/inst/examples/logistic.cpp
+++ b/inst/examples/logistic.cpp
@@ -1,0 +1,79 @@
+// [[dust::time_type(continuous)]]
+class logistic {
+public:
+  using data_type = mode::no_data;
+  using internal_type = mode::no_internal;
+  using rng_state_type = dust::random::generator<double>;
+
+  struct shared_type {
+    double r1;
+    double K1;
+    double r2;
+    double K2;
+  };
+
+  logistic(const mode::pars_type<logistic>& pars): shared(pars.shared) {
+  }
+
+  void rhs(double t,
+           const std::vector<double>& y,
+           std::vector<double>& dydt) const {
+    const double N1 = y[0];
+    const double N2 = y[1];
+    dydt[0] = shared->r1 * N1 * (1 - N1 / shared->K1);
+    dydt[1] = shared->r2 * N2 * (1 - N2 / shared->K2);
+  }
+
+  void output(double t,
+         const std::vector<double>& y,
+         std::vector<double>& output) {
+    const double N1 = y[0];
+    const double N2 = y[1];
+    output[0] = N1 + N2;
+  }
+
+  std::vector<double> initial(double time) {
+    std::vector<double> ret = {1, 1};
+    return ret;
+  }
+
+  void update_stochastic(double t, const std::vector<double>& y,
+                         rng_state_type& rng_state,
+                         std::vector<double>& y_next) {
+  }
+
+  size_t n_variables() const {
+    return 2;
+  }
+
+  size_t n_output() const {
+    return 1;
+  }
+
+private:
+  mode::shared_ptr<logistic> shared;
+};
+
+namespace mode {
+
+template <>
+mode::pars_type<logistic> mode_pars<logistic>(cpp11::list pars) {
+  // [[dust::param(r1, required = TRUE)]]
+  double r1 = cpp11::as_cpp<double>(pars["r1"]);
+  // [[dust::param(K1, required = TRUE)]]
+  double K1 = cpp11::as_cpp<double>(pars["K1"]);
+  // [[dust::param(r2, required = TRUE)]]
+  double r2 = cpp11::as_cpp<double>(pars["r2"]);
+  // [[dust::param(K2, required = TRUE)]]
+  double K2 = cpp11::as_cpp<double>(pars["K2"]);
+
+  logistic::shared_type shared{r1, K1, r2, K2};
+  return mode::pars_type<logistic>(shared);
+}
+
+template <>
+cpp11::sexp mode_info<logistic>(const mode::pars_type<logistic>& pars) {
+  return cpp11::writable::strings({"N1", "N2"});
+}
+
+}

--- a/tests/testthat/test-metadata.R
+++ b/tests/testthat/test-metadata.R
@@ -2,6 +2,7 @@ test_that("parse sir model metadata", {
   meta <- parse_metadata(dust_file("examples/sir.cpp"))
   expect_equal(meta$class, "sir")
   expect_equal(meta$name, "sir")
+  expect_equal(meta$time_type, "discrete")
   expect_equal(
     meta$param,
     list(I0 = list(required = FALSE),
@@ -218,5 +219,31 @@ test_that("Can prevent invalid names", {
   expect_error(
     parse_metadata(tmp),
     "'[[dust::name]]' must contain only letters, numbers and underscores",
+    fixed = TRUE)
+})
+
+
+test_that("Can parse metadata for continuous time models", {
+  meta <- parse_metadata(dust_file("examples/logistic.cpp"))
+  expect_equal(meta$class, "logistic")
+  expect_equal(meta$name, "logistic")
+  expect_equal(meta$time_type, "continuous")
+  expect_equal(
+    meta$param,
+    list(r1 = list(required = TRUE),
+         K1 = list(required = TRUE),
+         r2 = list(required = TRUE),
+         K2 = list(required = TRUE)))
+})
+
+
+test_that("Validate time type where given", {
+  tmp <- helper_metadata(
+    "// [[dust::time_type(surreal)]]")
+  on.exit(unlink(tmp))
+  expect_error(
+    parse_metadata(tmp),
+    paste("Invalid value for dust::time_type, expected one of",
+          "'continuous', 'discrete'"),
     fixed = TRUE)
 })


### PR DESCRIPTION
Adds support for parsing an additional bit of metadata, we'll need this to be able to process mode models smoothly from within dust