### PR TITLE
Add support for linking to other packages

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dust
 Title: Iterate Multiple Realisations of Stochastic Models
-Version: 0.12.3
+Version: 0.12.4
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Alex", "Hill", role = "aut"),

--- a/R/cpp11.R
+++ b/R/cpp11.R
@@ -24,6 +24,18 @@ density_poisson <- function(x, lambda, log) {
   .Call(`_dust_density_poisson`, x, lambda, log)
 }
 
+dust_rng_pointer_init <- function(n_streams, seed, long_jump, algorithm) {
+  .Call(`_dust_dust_rng_pointer_init`, n_streams, seed, long_jump, algorithm)
+}
+
+dust_rng_pointer_sync <- function(obj, algorithm) {
+  invisible(.Call(`_dust_dust_rng_pointer_sync`, obj, algorithm))
+}
+
+test_rng_pointer_get <- function(obj, n_streams) {
+  .Call(`_dust_test_rng_pointer_get`, obj, n_streams)
+}
+
 dust_rng_alloc <- function(r_seed, n_streams, deterministic, is_float) {
   .Call(`_dust_dust_rng_alloc`, r_seed, n_streams, deterministic, is_float)
 }
@@ -82,18 +94,6 @@ dust_rng_multinomial <- function(ptr, n, r_size, r_prob, n_threads, is_float) {
 
 dust_rng_state <- function(ptr, is_float) {
   .Call(`_dust_dust_rng_state`, ptr, is_float)
-}
-
-dust_rng_pointer_init <- function(n_streams, seed, long_jump, algorithm) {
-  .Call(`_dust_dust_rng_pointer_init`, n_streams, seed, long_jump, algorithm)
-}
-
-dust_rng_pointer_sync <- function(obj, algorithm) {
-  invisible(.Call(`_dust_dust_rng_pointer_sync`, obj, algorithm))
-}
-
-test_rng_pointer_get <- function(obj, n_streams) {
-  .Call(`_dust_test_rng_pointer_get`, obj, n_streams)
 }
 
 cpp_openmp_info <- function() {

--- a/R/cuda.R
+++ b/R/cuda.R
@@ -257,7 +257,7 @@ cuda_create_test_package <- function(path_cuda_lib, path = tempfile()) {
   dir.create(path_src, FALSE, TRUE)
   data <- list(base = base,
                path_dust_include = dust_file("include"),
-               linking_to = NULL,
+               linking_to = "cpp11",
                cuda = list(gencode = "",
                            nvcc_flags = "-O0",
                            cub_include = "",

--- a/R/cuda.R
+++ b/R/cuda.R
@@ -257,6 +257,7 @@ cuda_create_test_package <- function(path_cuda_lib, path = tempfile()) {
   dir.create(path_src, FALSE, TRUE)
   data <- list(base = base,
                path_dust_include = dust_file("include"),
+               linking_to = NULL,
                cuda = list(gencode = "",
                            nvcc_flags = "-O0",
                            cub_include = "",

--- a/R/interface.R
+++ b/R/interface.R
@@ -179,6 +179,11 @@
 ##'   real type will typically just decrease precision for no
 ##'   additional performance.
 ##'
+##' @param linking_to Optionally, a character vector of additional
+##'   packages to add to the `DESCRIPTION`'s `LinkingTo` field. Use
+##'   this when your model pulls in C++ code that is packaged within
+##'   another package's header-only library.
+##'
 ##' @param skip_cache Logical, indicating if the cache of previously
 ##'   compiled models should be skipped. If `TRUE` then your model will
 ##'   not be looked for in the cache, nor will it be added to the
@@ -229,9 +234,9 @@
 ##' # See the state again
 ##' obj$state()
 dust <- function(filename, quiet = FALSE, workdir = NULL, gpu = FALSE,
-                 real_type = NULL, skip_cache = FALSE) {
+                 real_type = NULL, linking_to = NULL, skip_cache = FALSE) {
   filename <- dust_prepare(filename, real_type)
-  compile_and_load(filename, quiet, workdir, cuda_check(gpu),
+  compile_and_load(filename, quiet, workdir, cuda_check(gpu), linking_to,
                    skip_cache)
 }
 
@@ -266,9 +271,11 @@ dust <- function(filename, quiet = FALSE, workdir = NULL, gpu = FALSE,
 ##' dir(file.path(path, "R"))
 ##' dir(file.path(path, "src"))
 dust_generate <- function(filename, quiet = FALSE, workdir = NULL, gpu = FALSE,
-                          real_type = NULL, mangle = FALSE) {
+                          real_type = NULL, linking_to = NULL, mangle = FALSE) {
   filename <- dust_prepare(filename, real_type)
-  res <- generate_dust(filename, quiet, workdir, cuda_check(gpu), TRUE, mangle)
+  skip_cache <- TRUE
+  res <- generate_dust(filename, quiet, workdir, cuda_check(gpu), linking_to,
+                       skip_cache, mangle)
   cpp11::cpp_register(res$path, quiet = quiet)
   res$path
 }

--- a/R/package.R
+++ b/R/package.R
@@ -201,7 +201,7 @@ package_validate_namespace_usedynlib <- function(exprs, name) {
 package_generate <- function(filename) {
   config <- parse_metadata(filename)
   model <- read_lines(filename)
-  data <- dust_template_data(model, config, NULL, NULL)
+  data <- dust_template_data(model, config, NULL, NULL, NULL)
 
   code <- dust_code(data, config)
 

--- a/inst/template/DESCRIPTION
+++ b/inst/template/DESCRIPTION
@@ -1,4 +1,4 @@
 Package: {{base}}
-LinkingTo: cpp11
+LinkingTo: {{linking_to}}
 Version: 0.0.1
 SystemRequirements: C++11

--- a/man/dust.Rd
+++ b/man/dust.Rd
@@ -10,6 +10,7 @@ dust(
   workdir = NULL,
   gpu = FALSE,
   real_type = NULL,
+  linking_to = NULL,
   skip_cache = FALSE
 )
 }
@@ -41,6 +42,11 @@ that will use 32 bit \code{floats} (rather than 64 bit doubles, which
 are much slower). For CPU models decreasing precision of your
 real type will typically just decrease precision for no
 additional performance.}
+
+\item{linking_to}{Optionally, a character vector of additional
+packages to add to the \code{DESCRIPTION}'s \code{LinkingTo} field. Use
+this when your model pulls in C++ code that is packaged within
+another package's header-only library.}
 
 \item{skip_cache}{Logical, indicating if the cache of previously
 compiled models should be skipped. If \code{TRUE} then your model will

--- a/man/dust_generate.Rd
+++ b/man/dust_generate.Rd
@@ -10,6 +10,7 @@ dust_generate(
   workdir = NULL,
   gpu = FALSE,
   real_type = NULL,
+  linking_to = NULL,
   mangle = FALSE
 )
 }
@@ -41,6 +42,11 @@ that will use 32 bit \code{floats} (rather than 64 bit doubles, which
 are much slower). For CPU models decreasing precision of your
 real type will typically just decrease precision for no
 additional performance.}
+
+\item{linking_to}{Optionally, a character vector of additional
+packages to add to the \code{DESCRIPTION}'s \code{LinkingTo} field. Use
+this when your model pulls in C++ code that is packaged within
+another package's header-only library.}
 
 \item{mangle}{Logical, indicating if the model name should be
 mangled when creating the package. This is safer if you will

--- a/src/cpp11.cpp
+++ b/src/cpp11.cpp
@@ -47,6 +47,28 @@ extern "C" SEXP _dust_density_poisson(SEXP x, SEXP lambda, SEXP log) {
     return cpp11::as_sexp(density_poisson(cpp11::as_cpp<cpp11::decay_t<cpp11::integers>>(x), cpp11::as_cpp<cpp11::decay_t<cpp11::doubles>>(lambda), cpp11::as_cpp<cpp11::decay_t<bool>>(log)));
   END_CPP11
 }
+// dust_rng_pointer.cpp
+cpp11::sexp dust_rng_pointer_init(int n_streams, cpp11::sexp seed, int long_jump, std::string algorithm);
+extern "C" SEXP _dust_dust_rng_pointer_init(SEXP n_streams, SEXP seed, SEXP long_jump, SEXP algorithm) {
+  BEGIN_CPP11
+    return cpp11::as_sexp(dust_rng_pointer_init(cpp11::as_cpp<cpp11::decay_t<int>>(n_streams), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(seed), cpp11::as_cpp<cpp11::decay_t<int>>(long_jump), cpp11::as_cpp<cpp11::decay_t<std::string>>(algorithm)));
+  END_CPP11
+}
+// dust_rng_pointer.cpp
+void dust_rng_pointer_sync(cpp11::environment obj, std::string algorithm);
+extern "C" SEXP _dust_dust_rng_pointer_sync(SEXP obj, SEXP algorithm) {
+  BEGIN_CPP11
+    dust_rng_pointer_sync(cpp11::as_cpp<cpp11::decay_t<cpp11::environment>>(obj), cpp11::as_cpp<cpp11::decay_t<std::string>>(algorithm));
+    return R_NilValue;
+  END_CPP11
+}
+// dust_rng_pointer.cpp
+double test_rng_pointer_get(cpp11::environment obj, int n_streams);
+extern "C" SEXP _dust_test_rng_pointer_get(SEXP obj, SEXP n_streams) {
+  BEGIN_CPP11
+    return cpp11::as_sexp(test_rng_pointer_get(cpp11::as_cpp<cpp11::decay_t<cpp11::environment>>(obj), cpp11::as_cpp<cpp11::decay_t<int>>(n_streams)));
+  END_CPP11
+}
 // dust_rng.cpp
 SEXP dust_rng_alloc(cpp11::sexp r_seed, int n_streams, bool deterministic, bool is_float);
 extern "C" SEXP _dust_dust_rng_alloc(SEXP r_seed, SEXP n_streams, SEXP deterministic, SEXP is_float) {
@@ -152,28 +174,6 @@ cpp11::sexp dust_rng_state(SEXP ptr, bool is_float);
 extern "C" SEXP _dust_dust_rng_state(SEXP ptr, SEXP is_float) {
   BEGIN_CPP11
     return cpp11::as_sexp(dust_rng_state(cpp11::as_cpp<cpp11::decay_t<SEXP>>(ptr), cpp11::as_cpp<cpp11::decay_t<bool>>(is_float)));
-  END_CPP11
-}
-// dust_rng_pointer.cpp
-cpp11::sexp dust_rng_pointer_init(int n_streams, cpp11::sexp seed, int long_jump, std::string algorithm);
-extern "C" SEXP _dust_dust_rng_pointer_init(SEXP n_streams, SEXP seed, SEXP long_jump, SEXP algorithm) {
-  BEGIN_CPP11
-    return cpp11::as_sexp(dust_rng_pointer_init(cpp11::as_cpp<cpp11::decay_t<int>>(n_streams), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(seed), cpp11::as_cpp<cpp11::decay_t<int>>(long_jump), cpp11::as_cpp<cpp11::decay_t<std::string>>(algorithm)));
-  END_CPP11
-}
-// dust_rng_pointer.cpp
-void dust_rng_pointer_sync(cpp11::environment obj, std::string algorithm);
-extern "C" SEXP _dust_dust_rng_pointer_sync(SEXP obj, SEXP algorithm) {
-  BEGIN_CPP11
-    dust_rng_pointer_sync(cpp11::as_cpp<cpp11::decay_t<cpp11::environment>>(obj), cpp11::as_cpp<cpp11::decay_t<std::string>>(algorithm));
-    return R_NilValue;
-  END_CPP11
-}
-// dust_rng_pointer.cpp
-double test_rng_pointer_get(cpp11::environment obj, int n_streams);
-extern "C" SEXP _dust_test_rng_pointer_get(SEXP obj, SEXP n_streams) {
-  BEGIN_CPP11
-    return cpp11::as_sexp(test_rng_pointer_get(cpp11::as_cpp<cpp11::decay_t<cpp11::environment>>(obj), cpp11::as_cpp<cpp11::decay_t<int>>(n_streams)));
   END_CPP11
 }
 // openmp.cpp

--- a/tests/testthat/test-gpu.R
+++ b/tests/testthat/test-gpu.R
@@ -290,6 +290,9 @@ test_that("Can generate test package code", {
   expect_setequal(
     dir(file.path(res$path, "src")),
     c("dust.cu", "dust.hpp", "Makevars"))
+  desc <- read.dcf(file.path(res$path, "DESCRIPTION"))
+  expect_setequal(colnames(desc),
+                  c("Package", "LinkingTo", "Version", "SystemRequirements"))
   txt <- readLines(file.path(res$path, "src", "Makevars"))
   expect_match(txt, "-L/path/to/cuda", all = FALSE, fixed = TRUE)
   expect_false(any(grepl("gencode", txt)))

--- a/tests/testthat/test-gpu.R
+++ b/tests/testthat/test-gpu.R
@@ -83,7 +83,7 @@ test_that("Can generate cuda compatible code", {
 
   workdir <- tempfile()
   res <- generate_dust(dust_file("examples/sirs.cpp"), TRUE, workdir, cuda,
-                       TRUE, TRUE)
+                       NULL, TRUE, TRUE)
 
   expect_setequal(
     dir(file.path(res$path, "src")),

--- a/tests/testthat/test-interface.R
+++ b/tests/testthat/test-interface.R
@@ -20,7 +20,7 @@ test_that("Interface passes arguments as expected", {
   mockery::expect_called(mock_compile_and_load, 1L)
   expect_equal(
     mockery::mock_args(mock_compile_and_load)[[1]],
-    list(filename, TRUE, workdir, NULL, FALSE))
+    list(filename, TRUE, workdir, NULL, NULL, FALSE))
 })
 
 

--- a/tests/testthat/test-interface.R
+++ b/tests/testthat/test-interface.R
@@ -386,10 +386,32 @@ test_that("create temporary package", {
   expect_match(
     read.dcf(file.path(path, "DESCRIPTION"))[, "Package"],
     "^walk[[:xdigit:]]{8}$")
+  desc <- as.list(read.dcf(file.path(path, "DESCRIPTION"))[1, ])
+  expect_equal(desc[["LinkingTo"]], "cpp11")
   pkg <- pkgload::load_all(path, quiet = TRUE, export_all = FALSE)
   expect_s3_class(pkg$env$walk, "dust_generator")
   obj <- pkg$env$walk$new(list(sd = 1), 0L, 100L)
   expect_s3_class(obj, "dust")
+})
+
+
+test_that("link to more packages at compilation", {
+  skip_on_cran()
+  filename <- dust_file("examples/walk.cpp")
+  path <- dust_generate(filename, quiet = TRUE, mangle = FALSE,
+                        linking_to = c("pkg1", "pkg2"))
+  desc <- as.list(read.dcf(file.path(path, "DESCRIPTION"))[1, ])
+  expect_equal(desc[["LinkingTo"]], "cpp11, pkg1, pkg2")
+})
+
+
+test_that("don't repeat cpp11 if given twice", {
+  skip_on_cran()
+  filename <- dust_file("examples/walk.cpp")
+  path <- dust_generate(filename, quiet = TRUE, mangle = FALSE,
+                        linking_to = c("pkg1", "cpp11", "pkg2"))
+  desc <- as.list(read.dcf(file.path(path, "DESCRIPTION"))[1, ])
+  expect_equal(desc[["LinkingTo"]], "cpp11, pkg1, pkg2")
 })
 
 


### PR DESCRIPTION
An additional argument that contains a vector of packages to "link" against. We need this if a dust model uses C++ support code that another package bundles. It's already easy if the user is using a dust package, but does not work currently with``dust::dust` and that's how we typically do gpu model generation...