### PR TITLE
mrc-3831: allow control over C++11 standard

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dust
 Title: Iterate Multiple Realisations of Stochastic Models
-Version: 0.12.4
+Version: 0.12.5
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Alex", "Hill", role = "aut"),

--- a/R/cuda.R
+++ b/R/cuda.R
@@ -258,6 +258,7 @@ cuda_create_test_package <- function(path_cuda_lib, path = tempfile()) {
   data <- list(base = base,
                path_dust_include = dust_file("include"),
                linking_to = "cpp11",
+               cpp_std = "C++11",
                cuda = list(gencode = "",
                            nvcc_flags = "-O0",
                            cub_include = "",

--- a/R/interface.R
+++ b/R/interface.R
@@ -184,6 +184,13 @@
 ##'   this when your model pulls in C++ code that is packaged within
 ##'   another package's header-only library.
 ##'
+##' @param cpp_std The C++ standard to use. This will be be set into
+##'   the `DESCRIPTION` of the package as the `SystemRequirements`
+##'   field. Sensible options are `C++11`, `C++14` etc. See the
+##'   section "Using C++ code" in "Writing R extensions". The minimum
+##'   allowed version is C++11 but R supports much more recent
+##'   versions now (especially more recent versions of R).
+##'
 ##' @param skip_cache Logical, indicating if the cache of previously
 ##'   compiled models should be skipped. If `TRUE` then your model will
 ##'   not be looked for in the cache, nor will it be added to the
@@ -234,10 +241,11 @@
 ##' # See the state again
 ##' obj$state()
 dust <- function(filename, quiet = FALSE, workdir = NULL, gpu = FALSE,
-                 real_type = NULL, linking_to = NULL, skip_cache = FALSE) {
+                 real_type = NULL, linking_to = NULL, cpp_std = NULL,
+                 skip_cache = FALSE) {
   filename <- dust_prepare(filename, real_type)
   compile_and_load(filename, quiet, workdir, cuda_check(gpu), linking_to,
-                   skip_cache)
+                   cpp_std, skip_cache)
 }
 
 
@@ -271,11 +279,12 @@ dust <- function(filename, quiet = FALSE, workdir = NULL, gpu = FALSE,
 ##' dir(file.path(path, "R"))
 ##' dir(file.path(path, "src"))
 dust_generate <- function(filename, quiet = FALSE, workdir = NULL, gpu = FALSE,
-                          real_type = NULL, linking_to = NULL, mangle = FALSE) {
+                          real_type = NULL, linking_to = NULL, cpp_std = NULL,
+                          mangle = FALSE) {
   filename <- dust_prepare(filename, real_type)
   skip_cache <- TRUE
   res <- generate_dust(filename, quiet, workdir, cuda_check(gpu), linking_to,
-                       skip_cache, mangle)
+                       cpp_std, skip_cache, mangle)
   cpp11::cpp_register(res$path, quiet = quiet)
   res$path
 }

--- a/R/package.R
+++ b/R/package.R
@@ -201,7 +201,7 @@ package_validate_namespace_usedynlib <- function(exprs, name) {
 package_generate <- function(filename) {
   config <- parse_metadata(filename)
   model <- read_lines(filename)
-  data <- dust_template_data(model, config, NULL, NULL, NULL)
+  data <- dust_template_data(model, config, NULL, NULL, NULL, NULL)
 
   code <- dust_code(data, config)
 
@@ -228,8 +228,7 @@ package_validate_uses_cpp11 <- function(path) {
   makevars <- file.path(path, "src", "Makevars")
 
   has_cpp11_desc <- desc$has_fields("SystemRequirements") &&
-    grepl("\\bC\\+\\+[0-9][0-9a-z]\\b", desc$get_field("SystemRequirements"),
-          ignore.case = TRUE)
+    is_valid_cpp_std(desc$get_field("SystemRequirements"))
   has_cpp11_makevars <-
     file.exists(makevars) && any(grepl("^CXX_STD\\b", readLines(makevars)))
 

--- a/inst/template/DESCRIPTION
+++ b/inst/template/DESCRIPTION
@@ -1,4 +1,4 @@
 Package: {{base}}
 LinkingTo: {{linking_to}}
 Version: 0.0.1
-SystemRequirements: C++11
+SystemRequirements: {{cpp_std}}

--- a/man/dust.Rd
+++ b/man/dust.Rd
@@ -11,6 +11,7 @@ dust(
   gpu = FALSE,
   real_type = NULL,
   linking_to = NULL,
+  cpp_std = NULL,
   skip_cache = FALSE
 )
 }
@@ -47,6 +48,13 @@ additional performance.}
 packages to add to the \code{DESCRIPTION}'s \code{LinkingTo} field. Use
 this when your model pulls in C++ code that is packaged within
 another package's header-only library.}
+
+\item{cpp_std}{The C++ standard to use. This will be be set into
+the \code{DESCRIPTION} of the package as the \code{SystemRequirements}
+field. Sensible options are \code{C++11}, \code{C++14} etc. See the
+section "Using C++ code" in "Writing R extensions". The minimum
+allowed version is C++11 but R supports much more recent
+versions now (especially more recent versions of R).}
 
 \item{skip_cache}{Logical, indicating if the cache of previously
 compiled models should be skipped. If \code{TRUE} then your model will

--- a/man/dust_generate.Rd
+++ b/man/dust_generate.Rd
@@ -11,6 +11,7 @@ dust_generate(
   gpu = FALSE,
   real_type = NULL,
   linking_to = NULL,
+  cpp_std = NULL,
   mangle = FALSE
 )
 }
@@ -47,6 +48,13 @@ additional performance.}
 packages to add to the \code{DESCRIPTION}'s \code{LinkingTo} field. Use
 this when your model pulls in C++ code that is packaged within
 another package's header-only library.}
+
+\item{cpp_std}{The C++ standard to use. This will be be set into
+the \code{DESCRIPTION} of the package as the \code{SystemRequirements}
+field. Sensible options are \code{C++11}, \code{C++14} etc. See the
+section "Using C++ code" in "Writing R extensions". The minimum
+allowed version is C++11 but R supports much more recent
+versions now (especially more recent versions of R).}
 
 \item{mangle}{Logical, indicating if the model name should be
 mangled when creating the package. This is safer if you will

--- a/tests/testthat/test-gpu.R
+++ b/tests/testthat/test-gpu.R
@@ -83,7 +83,7 @@ test_that("Can generate cuda compatible code", {
 
   workdir <- tempfile()
   res <- generate_dust(dust_file("examples/sirs.cpp"), TRUE, workdir, cuda,
-                       NULL, TRUE, TRUE)
+                       NULL, NULL, TRUE, TRUE)
 
   expect_setequal(
     dir(file.path(res$path, "src")),


### PR DESCRIPTION
Follows #380, with a very similar approach. Allows specifying the C++ standard at compilation. We already support packages using versions of C++ more recent than C++11 but the dust::dust interface does not support that! We need C++14 for some GPU models, specifically to use templated constexpr values at the global scope.

See https://github.com/mrc-ide/dust/compare/mrc-3830...mrc-3831 for diff