### PR TITLE
Remove explicit C++11 standard setting

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dust
 Title: Iterate Multiple Realisations of Stochastic Models
-Version: 0.14.0
+Version: 0.14.1
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Alex", "Hill", role = "aut"),
@@ -20,10 +20,10 @@ Description: An Engine for simulation of stochastic models. Includes
     FitzJohn et al 2021 <doi:10.12688/wellcomeopenres.16466.2>.
 URL: https://github.com/mrc-ide/dust
 BugReports: https://github.com/mrc-ide/dust/issues
-SystemRequirements: C++11
 License: MIT + file LICENSE
 Encoding: UTF-8
 Language: en-GB
+Requires: R (>= 4.0.0)
 Imports:
     R6,
     cpp11 (>= 0.2.6),

--- a/R/compile.R
+++ b/R/compile.R
@@ -26,6 +26,7 @@ generate_dust <- function(filename, quiet, workdir, cuda, linking_to, cpp_std,
   ## These two are used in the non-package version only
   data$base <- base
   data$path_dust_include <- dust_file("include")
+  data$system_requirements <- data$cpp_std %||% "R (>= 4.0.0)"
 
   dir.create(file.path(path, "R"), FALSE, TRUE)
   dir.create(file.path(path, "src"), FALSE, TRUE)
@@ -242,12 +243,14 @@ dust_repair_environment <- function(generator, quiet = FALSE) {
 
 
 is_valid_cpp_std <- function(cpp_std) {
-  grepl("\\bC\\+\\+[0-9][0-9a-z]\\b", cpp_std, ignore.case = TRUE)
+  grepl("^C\\+\\+[0-9][0-9a-z]$", cpp_std, ignore.case = TRUE)
 }
 
 
 validate_cpp_std <- function(cpp_std) {
-  cpp_std <- cpp_std %||% "C++11"
+  if (is.null(cpp_std)) {
+    return(NULL)
+  }
   assert_is(cpp_std, "character")
   if (length(cpp_std) != 1L) {
     stop("Expected a scalar character for 'cpp_std'")

--- a/R/cuda.R
+++ b/R/cuda.R
@@ -258,7 +258,6 @@ cuda_create_test_package <- function(path_cuda_lib, path = tempfile()) {
   data <- list(base = base,
                path_dust_include = dust_file("include"),
                linking_to = "cpp11",
-               cpp_std = "C++11",
                cuda = list(gencode = "",
                            nvcc_flags = "-O0",
                            cub_include = "",

--- a/R/cuda.R
+++ b/R/cuda.R
@@ -258,6 +258,7 @@ cuda_create_test_package <- function(path_cuda_lib, path = tempfile()) {
   data <- list(base = base,
                path_dust_include = dust_file("include"),
                linking_to = "cpp11",
+               system_requirements = "R (>= 4.0.0)",
                cuda = list(gencode = "",
                            nvcc_flags = "-O0",
                            cub_include = "",

--- a/R/interface.R
+++ b/R/interface.R
@@ -184,12 +184,14 @@
 ##'   this when your model pulls in C++ code that is packaged within
 ##'   another package's header-only library.
 ##'
-##' @param cpp_std The C++ standard to use. This will be be set into
-##'   the `DESCRIPTION` of the package as the `SystemRequirements`
-##'   field. Sensible options are `C++11`, `C++14` etc. See the
-##'   section "Using C++ code" in "Writing R extensions". The minimum
-##'   allowed version is C++11 but R supports much more recent
-##'   versions now (especially more recent versions of R).
+##' @param cpp_std The C++ standard to use, if you need to set one
+##'   explicitly. See the section "Using C++ code" in "Writing R
+##'   extensions" for the details of this, and how it interacts with
+##'   the R version currently being used. For R 4.0.0 and above, C++11
+##'   will be used; as dust depends on at least this version of R you
+##'   will never need to specify a version this low. Sensible options
+##'   are `C++14`, `C++17`, etc, depending on the features you need
+##'   and what your compiler supports.
 ##'
 ##' @param skip_cache Logical, indicating if the cache of previously
 ##'   compiled models should be skipped. If `TRUE` then your model will

--- a/R/package.R
+++ b/R/package.R
@@ -60,8 +60,7 @@
 ##' dir.create(file.path(dest, "inst/dust"), FALSE, TRUE)
 ##' writeLines(c("Package: example",
 ##'              "Version: 0.0.1",
-##'              "LinkingTo: cpp11, dust",
-##'              "SystemRequirements: C++11"),
+##'              "LinkingTo: cpp11, dust"),
 ##'            file.path(dest, "DESCRIPTION"))
 ##' writeLines("useDynLib('example', .registration = TRUE)",
 ##'            file.path(dest, "NAMESPACE"))
@@ -146,7 +145,6 @@ package_validate <- function(path) {
       "Package name must not contain '.' or '_' (found '%s')", name))
   }
   package_validate_namespace(file.path(path, "NAMESPACE"), name)
-  package_validate_uses_cpp11(path)
 
   path
 }
@@ -219,22 +217,5 @@ package_validate_makevars_openmp <- function(text) {
     grepl("SHLIB_OPENMP_CXXFLAGS", text)
   if (!ok) {
     stop("Package has a 'src/Makevars' but no openmp flags support")
-  }
-}
-
-
-package_validate_uses_cpp11 <- function(path) {
-  desc <- pkgload::pkg_desc(file.path(path, "DESCRIPTION"))
-  makevars <- file.path(path, "src", "Makevars")
-
-  has_cpp11_desc <- desc$has_fields("SystemRequirements") &&
-    is_valid_cpp_std(desc$get_field("SystemRequirements"))
-  has_cpp11_makevars <-
-    file.exists(makevars) && any(grepl("^CXX_STD\\b", readLines(makevars)))
-
-  has_cpp11 <- has_cpp11_desc || has_cpp11_makevars
-
-  if (!has_cpp11) {
-    stop("Did not find a SystemRequirements: C++11 (or similar) in DESCRIPTION")
   }
 }

--- a/inst/random/package/DESCRIPTION
+++ b/inst/random/package/DESCRIPTION
@@ -8,4 +8,3 @@ Description: Simple example package showing how to use dust's random
 License: CC0
 Encoding: UTF-8
 LinkingTo: cpp11, dust
-SystemRequirements: C++11

--- a/inst/template/DESCRIPTION
+++ b/inst/template/DESCRIPTION
@@ -1,4 +1,4 @@
 Package: {{base}}
 LinkingTo: {{linking_to}}
 Version: 0.0.1
-SystemRequirements: {{cpp_std}}
+SystemRequirements: {{system_requirements}}

--- a/man/dust.Rd
+++ b/man/dust.Rd
@@ -49,12 +49,14 @@ packages to add to the \code{DESCRIPTION}'s \code{LinkingTo} field. Use
 this when your model pulls in C++ code that is packaged within
 another package's header-only library.}
 
-\item{cpp_std}{The C++ standard to use. This will be be set into
-the \code{DESCRIPTION} of the package as the \code{SystemRequirements}
-field. Sensible options are \code{C++11}, \code{C++14} etc. See the
-section "Using C++ code" in "Writing R extensions". The minimum
-allowed version is C++11 but R supports much more recent
-versions now (especially more recent versions of R).}
+\item{cpp_std}{The C++ standard to use, if you need to set one
+explicitly. See the section "Using C++ code" in "Writing R
+extensions" for the details of this, and how it interacts with
+the R version currently being used. For R 4.0.0 and above, C++11
+will be used; as dust depends on at least this version of R you
+will never need to specify a version this low. Sensible options
+are \code{C++14}, \code{C++17}, etc, depending on the features you need
+and what your compiler supports.}
 
 \item{skip_cache}{Logical, indicating if the cache of previously
 compiled models should be skipped. If \code{TRUE} then your model will

--- a/man/dust_generate.Rd
+++ b/man/dust_generate.Rd
@@ -49,12 +49,14 @@ packages to add to the \code{DESCRIPTION}'s \code{LinkingTo} field. Use
 this when your model pulls in C++ code that is packaged within
 another package's header-only library.}
 
-\item{cpp_std}{The C++ standard to use. This will be be set into
-the \code{DESCRIPTION} of the package as the \code{SystemRequirements}
-field. Sensible options are \code{C++11}, \code{C++14} etc. See the
-section "Using C++ code" in "Writing R extensions". The minimum
-allowed version is C++11 but R supports much more recent
-versions now (especially more recent versions of R).}
+\item{cpp_std}{The C++ standard to use, if you need to set one
+explicitly. See the section "Using C++ code" in "Writing R
+extensions" for the details of this, and how it interacts with
+the R version currently being used. For R 4.0.0 and above, C++11
+will be used; as dust depends on at least this version of R you
+will never need to specify a version this low. Sensible options
+are \code{C++14}, \code{C++17}, etc, depending on the features you need
+and what your compiler supports.}
 
 \item{mangle}{Logical, indicating if the model name should be
 mangled when creating the package. This is safer if you will

--- a/man/dust_package.Rd
+++ b/man/dust_package.Rd
@@ -63,8 +63,7 @@ dir.create(dest)
 dir.create(file.path(dest, "inst/dust"), FALSE, TRUE)
 writeLines(c("Package: example",
              "Version: 0.0.1",
-             "LinkingTo: cpp11, dust",
-             "SystemRequirements: C++11"),
+             "LinkingTo: cpp11, dust"),
            file.path(dest, "DESCRIPTION"))
 writeLines("useDynLib('example', .registration = TRUE)",
            file.path(dest, "NAMESPACE"))

--- a/tests/testthat/examples/pkg/DESCRIPTION
+++ b/tests/testthat/examples/pkg/DESCRIPTION
@@ -7,4 +7,3 @@ Title: An Example Using Dust
 Description: Provides an example of dust within a packge. Not intended to
     be used for anything really.
 License: CC0
-SystemRequirements: C++11

--- a/tests/testthat/test-interface.R
+++ b/tests/testthat/test-interface.R
@@ -400,7 +400,6 @@ test_that("create temporary package", {
     "^walk[[:xdigit:]]{8}$")
   desc <- as.list(read.dcf(file.path(path, "DESCRIPTION"))[1, ])
   expect_equal(desc[["LinkingTo"]], "cpp11")
-  expect_equal(desc[["SystemRequirements"]], "C++11")
   pkg <- pkgload::load_all(path, quiet = TRUE, export_all = FALSE)
   expect_s3_class(pkg$env$walk, "dust_generator")
   obj <- pkg$env$walk$new(list(sd = 1), 0L, 100L)
@@ -567,7 +566,7 @@ test_that("Can repair generators", {
 
 
 test_that("Can validate C++ standard", {
-  expect_equal(validate_cpp_std(NULL), "C++11")
+  expect_null(validate_cpp_std(NULL))
   expect_equal(validate_cpp_std("C++11"), "C++11")
   expect_equal(validate_cpp_std("c++11"), "c++11")
   expect_equal(validate_cpp_std("c++17"), "c++17")

--- a/tests/testthat/test-package.R
+++ b/tests/testthat/test-package.R
@@ -195,31 +195,6 @@ test_that("guide user to sensible package name", {
 })
 
 
-test_that("check that package uses C++11", {
-  path <- create_test_package()
-
-  expect_silent(
-    package_validate_uses_cpp11(path))
-
-  path_descr <- file.path(path, "DESCRIPTION")
-  descr <- grep("^SystemRequirements:", readLines(path_descr),
-                value = TRUE, invert = TRUE)
-  writeLines(descr, path_descr)
-
-  expect_error(
-    package_validate_uses_cpp11(path),
-    "Did not find a SystemRequirements: C++11 (or similar) in DESCRIPTION",
-    fixed = TRUE)
-
-  writeLines(
-    c("# some makevars file", "CXX_STD = C++11"),
-    file.path(path, "src", "Makevars"))
-
-  expect_silent(
-    package_validate_uses_cpp11(path))
-})
-
-
 test_that("can create package with ode model", {
   path <- create_test_package(
     "pkgode", examples = c("ode/logistic.cpp", "ode/parallel.cpp"))

--- a/vignettes/dust.Rmd
+++ b/vignettes/dust.Rmd
@@ -389,7 +389,6 @@ desc <- c(
   "LinkingTo: cpp11, dust",
   "Authors@R: c(person('A', 'Person', role = c('aut', 'cre')",
   "                     email = 'person@example.com'))",
-  "SystemRequirements: C++11",
   "License: CC0")
 ns <- "useDynLib('example', .registration = TRUE)"
 

--- a/vignettes/rng_package.Rmd
+++ b/vignettes/rng_package.Rmd
@@ -231,7 +231,6 @@ We have an extremely minimal `DESCRIPTION`, which contains line `LinkingTo: cpp1
 Package: piparallel
 LinkingTo: cpp11, dust
 Version: 0.0.1
-SystemRequirements: C++11
 ```
 
 The `NAMESPACE` loads the dynamic library

--- a/vignettes_src/rng_distributed.Rmd
+++ b/vignettes_src/rng_distributed.Rmd
@@ -86,8 +86,7 @@ dir.create(file.path(path, "src"), FALSE, TRUE)
 writeLines(
   c("Package: piparallel",
     "LinkingTo: cpp11, dust",
-    "Version: 0.0.1",
-    "SystemRequirements: C++11"),
+    "Version: 0.0.1"),
   file.path(path, "DESCRIPTION"))
 writeLines(
   c('useDynLib("piparallel", .registration = TRUE)',

--- a/vignettes_src/rng_package.Rmd
+++ b/vignettes_src/rng_package.Rmd
@@ -142,8 +142,7 @@ dir.create(file.path(path, "src"), FALSE, TRUE)
 writeLines(
   c("Package: piparallel",
     "LinkingTo: cpp11, dust",
-    "Version: 0.0.1",
-    "SystemRequirements: C++11"),
+    "Version: 0.0.1"),
   file.path(path, "DESCRIPTION"))
 writeLines(
   c('useDynLib("piparallel", .registration = TRUE)',


### PR DESCRIPTION
Relevant context:

* https://cran.r-project.org/doc/manuals/r-release/R-exts.html#Using-C_002b_002b-code
* https://github.com/tidyverse/readxl/pull/722/files
* https://stat.ethz.ch/pipermail/r-package-devel/2023q1/008870.html
* https://www.tidyverse.org/blog/2023/03/cran-checks-compiled-code/
 
It's highly unlikely that we work well with R before version 4 so I am happy to just require that version here anyway.